### PR TITLE
Proper objecting

### DIFF
--- a/lib/bali/dsl/map_rules_dsl.rb
+++ b/lib/bali/dsl/map_rules_dsl.rb
@@ -25,7 +25,7 @@ class Bali::MapRulesDsl
     raise Bali::DslError, "Subtarget must be a class" unless subtarget_class.is_a?(Class)
     raise Bali::DslError, "Field name must be a symbol/string" if !(field_name.is_a?(Symbol) || field_name.is_a?(String))
 
-    Bali::TRANSLATED_SUBTARGET_ROLES[subtarget_class.to_s] = field_name 
+    Bali::TRANSLATED_SUBTARGET_ROLES[subtarget_class.to_s] = field_name
     nil
   end
 
@@ -38,6 +38,11 @@ class Bali::MapRulesDsl
   end
 
   def cant(*params)
+    puts "Deprecation Warning: declaring rules with cant will be deprecated on major release 3.0, use cannot instead"
+    cannot *params
+  end
+
+  def cannot(*params)
     raise Bali::DslError, "cant block must be within describe block"
   end
 
@@ -46,6 +51,11 @@ class Bali::MapRulesDsl
   end
 
   def cant_all(*params)
+    puts "Deprecation Warning: declaring rules with cant_all will be deprecated on major release 3.0, use cannot instead"
+    cannot_all *params
+  end
+
+  def cannot_all(*params)
     raise Bali::DslError, "cant_all block must be within describe block"
   end
 end

--- a/lib/bali/dsl/rules_for_dsl.rb
+++ b/lib/bali/dsl/rules_for_dsl.rb
@@ -27,7 +27,7 @@ class Bali::RulesForDsl
         subtargets += passed_argument
       elsif passed_argument.is_a?(Hash)
         rules = passed_argument
-      else 
+      else
         raise Bali::DslError, "Allowed argument: symbol, string, nil and hash"
       end
     end
@@ -56,7 +56,7 @@ class Bali::RulesForDsl
               end
             else
               operation = operations # well, basically is 1 only
-              rule = Bali::Rule.new(auth_val, operation) 
+              rule = Bali::Rule.new(auth_val, operation)
               self.current_rule_group.add_rule(rule)
             end
           end # each rules
@@ -71,7 +71,7 @@ class Bali::RulesForDsl
   # to define can and cant is basically using this method
   def process_auth_rules(auth_val, operations)
     conditional_hash = nil
-    
+
     # scan operations for options
     operations.each do |elm|
       if elm.is_a?(Hash)
@@ -104,7 +104,7 @@ class Bali::RulesForDsl
   end
 
   def cannot(*operations)
-    process_auth_rules(:cant, operations)
+    process_auth_rules(:cannot, operations)
   end
 
   def cant(*operations)

--- a/lib/bali/foundations/rule/rule.rb
+++ b/lib/bali/foundations/rule/rule.rb
@@ -1,6 +1,6 @@
 # for internal use, representing one, single, atomic rule
 class Bali::Rule
-  # auth_val is either :can or :cant
+  # auth_val is either :can or :cannot
   attr_reader :auth_val
 
   # what is the operation: create, update, delete, or any other
@@ -18,10 +18,13 @@ class Bali::Rule
   end
 
   def auth_val=(aval)
-    if aval == :can || aval == :cant
+    # TODO: in version 3 remove :cant
+    if aval == :can || aval == :cannot
       @auth_val = aval
+    elsif aval == :cant
+      @auth_val = :cannot
     else
-      raise Bali::DslError, "auth_val can only either be :can or :cant"
+      raise Bali::DslError, "auth_val can only either be :can or :cannot"
     end
   end
 
@@ -34,7 +37,8 @@ class Bali::Rule
   end
 
   def is_discouragement?
-    self.auth_val == :cant
+    # TODO: in version 3.0 remove :cant
+    self.auth_val == :cannot || self.auth_val == :cant
   end
 
   def has_decider?

--- a/lib/bali/foundations/rule/rule_group.rb
+++ b/lib/bali/foundations/rule/rule_group.rb
@@ -59,7 +59,7 @@ class Bali::RuleGroup
     case auth_val
     when :can, "can"
       rule = self.cans[operation.to_sym]
-    when :cant, "cant"
+    when :cannot, "cannot"
       rule = self.cants[operation.to_sym]
     else
       raise Bali::DslError, "Undefined operation: #{auth_val}"

--- a/lib/bali/objector.rb
+++ b/lib/bali/objector.rb
@@ -7,7 +7,7 @@ module Bali::Objector
 
   # check whether user can/cant perform an operation, return true when positive
   # or false otherwise
-  def can?(subtargets, operation) 
+  def can?(subtargets, operation)
     self.class.can?(subtargets, operation, self)
   end
 
@@ -54,7 +54,7 @@ module Bali::Objector::Statics
 
       _subtarget = _subtarget_roles
       _subtarget_class = _subtarget.class.to_s
-      
+
       # variable to hold deducted role of the passed object
       deducted_roles = nil
 
@@ -80,7 +80,7 @@ module Bali::Objector::Statics
   ### options passable to bali_can? and bali_cannot? are:
   ### cross_action: if set to true wouldn't call its counterpart so as to prevent
   ###   overflowing stack
-  ### original_subtarget: the original passed to can? and cant? before 
+  ### original_subtarget: the original passed to can? and cannot? before
   ###   processed by bali_translate_subtarget_roles
 
   def bali_can?(subtarget, operation, record = self, options = {})
@@ -108,20 +108,20 @@ module Bali::Objector::Statics
     if rule_group.zeus?
       if rule.nil?
         # check further whether cant is defined to overwrite this can_all
-        if self.cant?(subtarget, operation, record, cross_check: true)
+        if self.cannot?(subtarget, operation, record, cross_check: true)
           return false
         else
           return true
         end
       end
     end
-    
+
     if rule.nil?
       # default if can? for undefined rule is false, after related clause
-      # cannot be found in cant?
+      # cannot be found in cannot?
       return false if options[:cross_check]
       options[:cross_check] = true
-      return !self.cant?(subtarget, operation, record, options)
+      return !self.cannot?(subtarget, operation, record, options)
     else
       if rule.has_decider?
         # must test first
@@ -131,43 +131,43 @@ module Bali::Objector::Statics
         when 0
           if rule.decider_type == :if
             if decider.()
-              return true 
-            else 
+              return true
+            else
               return false
             end
           elsif rule.decider_type == :unless
             unless decider.()
-              return true 
-            else 
-              return false 
+              return true
+            else
+              return false
             end
           end
         when 1
           if rule.decider_type == :if
             if decider.(record)
-              return true 
-            else 
+              return true
+            else
               return false
             end
           elsif rule.decider_type == :unless
             unless decider.(record)
-              return true 
-            else 
-              return false 
+              return true
+            else
+              return false
             end
           end
         when 2
           if rule.decider_type == :if
             if decider.(record, original_subtarget)
-              return true 
-            else 
+              return true
+            else
               return false
             end
           elsif rule.decider_type == :unless
             unless decider.(record, original_subtarget)
-              return true 
-            else 
-              return false 
+              return true
+            else
+              return false
             end
           end
         end
@@ -185,11 +185,11 @@ module Bali::Objector::Statics
       rule_group = Bali::Integrators::Rule.rule_group_for(self.class, subtarget)
     end
 
-    # default of cant? is true whenever RuleClass for that class is undefined
+    # default of cannot? is true whenever RuleClass for that class is undefined
     # or RuleGroup for that subtarget is not defined
     return true if rule_group.nil?
 
-    rule = rule_group.get_rule(:cant, operation)
+    rule = rule_group.get_rule(:cannot, operation)
 
     # godly subtarget is not to be prohibited in his endeavours
     # so long that no specific rule about this operation is defined
@@ -209,7 +209,7 @@ module Bali::Objector::Statics
       end
     end
 
-    # if rule cannot be found, then true is returned for cant? unless 
+    # if rule cannot be found, then true is returned for cannot? unless
     # can? is defined exactly for the same target, and subtarget, and record (if given)
     if rule.nil?
       return true if options[:cross_check]
@@ -223,43 +223,43 @@ module Bali::Objector::Statics
         when 0
           if rule.decider_type == :if
             if decider.()
-              return true 
-            else 
+              return true
+            else
               return false
             end
           elsif rule.decider_type == :unless
             unless decider.()
-              return true 
-            else 
-              return false 
+              return true
+            else
+              return false
             end
           end
         when 1
           if rule.decider_type == :if
             if decider.(record)
-              return true 
-            else 
+              return true
+            else
               return false
             end
           elsif rule.decider_type == :unless
             unless decider.(record)
-              return true 
-            else 
-              return false 
+              return true
+            else
+              return false
             end
           end
         when 2
           if rule.decider_type == :if
             if decider.(record, original_subtarget)
-              return true 
-            else 
+              return true
+            else
               return false
             end
           elsif rule.decider_type == :unless
             unless decider.(record, original_subtarget)
-              return true 
-            else 
-              return false 
+              return true
+            else
+              return false
             end
           end
         end
@@ -307,15 +307,15 @@ module Bali::Objector::Statics
       if cant_value == false
         role = subtarget
         if block_given?
-          yield options[:original_subtarget], role, false 
+          yield options[:original_subtarget], role, false
         else
           return false
         end
       end
     end
-    
+
     true
-  rescue => e 
+  rescue => e
     if e.is_a?(Bali::AuthorizationError)
       raise e
     else
@@ -331,7 +331,7 @@ module Bali::Objector::Statics
         auth_error.operation = operation
         auth_error.role = role
         auth_error.target = record
-        auth_error.subtarget = original_subtarget 
+        auth_error.subtarget = original_subtarget
 
         if role
           auth_error.subtarget = original_subtarget if !(original_subtarget.is_a?(Symbol) || original_subtarget.is_a?(String) || original_subtarget.is_a?(Array))
@@ -351,16 +351,16 @@ module Bali::Objector::Statics
     cannot?(subtarget_roles, operation, record, options) do |original_subtarget, role, cant_value|
       if cant_value == false
         auth_error = Bali::AuthorizationError.new
-        auth_error.auth_level = :cant
+        auth_error.auth_level = :cannot
         auth_error.operation = operation
         auth_error.role = role
         auth_error.target = record
-        auth_error.subtarget = original_subtarget 
+        auth_error.subtarget = original_subtarget
 
         if role
           auth_error.subtarget = original_subtarget if !(original_subtarget.is_a?(Symbol) || original_subtarget.is_a?(String) || original_subtarget.is_a?(Array))
         end
-        
+
         raise auth_error
       end
     end

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -9,7 +9,7 @@ describe Bali do
     end
 
     it "disallow calling describe outside of rules_for" do
-      expect do 
+      expect do
         Bali.map_rules do
           describe :general_user, can: :show
         end.to raise_error(Bali::DslError)
@@ -17,7 +17,7 @@ describe Bali do
 
       expect do
         Bali.map_rules do
-          rules_for My::Transaction do 
+          rules_for My::Transaction do
             describe :general_user do
               can :show
             end
@@ -27,15 +27,15 @@ describe Bali do
     end
 
     it "disallows calling can outside of describe block" do
-      expect do 
-        Bali.map_rules do 
+      expect do
+        Bali.map_rules do
           can :show
         end
       end.to raise_error(Bali::DslError)
 
       expect do
         Bali.map_rules do
-          rules_for My::Transaction do 
+          rules_for My::Transaction do
             describe :general_user do
               can :show
             end
@@ -44,34 +44,34 @@ describe Bali do
       end.to_not raise_error
     end
 
-    it "disallows calling cant outside of describe block" do 
-      expect do 
-        Bali.map_rules do 
-          cant :show
-        end
-      end.to raise_error(Bali::DslError)
-      
+    it "disallows calling cannot outside of describe block" do
       expect do
         Bali.map_rules do
-          rules_for My::Transaction do 
+          cannot :show
+        end
+      end.to raise_error(Bali::DslError)
+
+      expect do
+        Bali.map_rules do
+          rules_for My::Transaction do
             describe :general_user do
-              cant :show
+              cannot :show
             end
           end
         end
       end.to_not raise_error
     end
 
-    it "disallows calling can_all outside of describe block" do 
-      expect do 
-        Bali.map_rules do 
+    it "disallows calling can_all outside of describe block" do
+      expect do
+        Bali.map_rules do
           can_all
         end
       end.to raise_error(Bali::DslError)
 
-      expect do 
+      expect do
         Bali.map_rules do
-          rules_for My::Transaction do 
+          rules_for My::Transaction do
             describe :general_user do
               can_all
             end
@@ -80,18 +80,18 @@ describe Bali do
       end.to_not raise_error
     end
 
-    it "disallows calling cant_all outside of describe block" do 
-      expect do 
-        Bali.map_rules do 
-          cant_all
+    it "disallows calling cannot_all outside of describe block" do
+      expect do
+        Bali.map_rules do
+          cannot_all
         end
       end.to raise_error(Bali::DslError)
 
-      expect do 
+      expect do
         Bali.map_rules do
-          rules_for My::Transaction do 
+          rules_for My::Transaction do
             describe :general_user do
-              cant_all
+              cannot_all
             end
           end
         end
@@ -129,7 +129,7 @@ describe Bali do
 
       Bali::Integrators::Rule.rule_classes.size.should == 1
       Bali::Integrators::Rule.rule_class_for(My::Transaction).class.should == Bali::RuleClass
-      
+
       rule_group_gu = Bali::Integrators::Rule.rule_group_for(My::Transaction, :general_user)
       rule_group_fu = Bali::Integrators::Rule.rule_group_for(My::Transaction, :finance_user)
 
@@ -162,7 +162,7 @@ describe Bali do
     it "does not allows subtarget definition other than using string, symbol, array and hash" do
       expect do
         Bali.map_rules do
-          rules_for My::Transaction do 
+          rules_for My::Transaction do
             describe :general_user do
               can :print
             end
@@ -225,7 +225,7 @@ describe Bali do
         rules_for My::Transaction do
           describe :finance_user do
             can :delete, if: proc { |record| record.is_settled? }
-            cant :payout, if: proc { |record| !record.is_settled? }
+            cannot :payout, if: proc { |record| !record.is_settled? }
           end
         end
       end
@@ -233,22 +233,22 @@ describe Bali do
       txn = My::Transaction.new
       txn.is_settled = false
       txn.can?(:finance_user, :delete).should be_falsey
-      txn.cant?(:finance_user, :delete).should be_truthy
+      txn.cannot?(:finance_user, :delete).should be_truthy
       txn.can?(:finance_user, :payout).should be_falsey
-      txn.cant?(:finance_user, :payout).should be_truthy
+      txn.cannot?(:finance_user, :payout).should be_truthy
 
       txn.is_settled = true
       txn.can?(:finance_user, :delete).should be_truthy
-      txn.cant?(:finance_user, :delete).should be_falsey
+      txn.cannot?(:finance_user, :delete).should be_falsey
       txn.can?(:finance_user, :payout).should be_truthy
-      txn.cant?(:finance_user, :payout).should be_falsey
+      txn.cannot?(:finance_user, :payout).should be_falsey
 
       # reverse meaning of the above, should return the same
       Bali.clear_rules
       Bali.map_rules do
         rules_for My::Transaction do
           describe :finance_user do
-            cant :delete, unless: proc { |record| record.is_settled? }
+            cannot :delete, unless: proc { |record| record.is_settled? }
             can :payout, unless: proc { |record| !record.is_settled? }
           end
         end
@@ -257,11 +257,11 @@ describe Bali do
       txn = My::Transaction.new
       txn.is_settled = false
       txn.can?(:finance_user, :delete).should be_falsey
-      txn.cant?(:finance_user, :delete).should be_truthy
+      txn.cannot?(:finance_user, :delete).should be_truthy
 
       txn.is_settled = true
       txn.can?(:finance_user, :delete).should be_truthy
-      txn.cant?(:finance_user, :delete).should be_falsey
+      txn.cannot?(:finance_user, :delete).should be_falsey
     end
 
     it "allows unless-decider to be executed in context" do
@@ -269,18 +269,18 @@ describe Bali do
       Bali.map_rules do
         rules_for My::Transaction do
           describe :finance_user do
-            cant :chargeback, unless: proc { |record| record.is_settled? }
+            cannot :chargeback, unless: proc { |record| record.is_settled? }
           end
         end
       end
 
       txn = My::Transaction.new
       txn.is_settled = false
-      txn.cant?(:finance_user, :chargeback).should be_truthy
+      txn.cannot?(:finance_user, :chargeback).should be_truthy
       txn.can?(:finance_user, :chargeback).should be_falsey
-      
+
       txn.is_settled = true
-      txn.cant?(:finance_user, :chargeback).should be_falsey
+      txn.cannot?(:finance_user, :chargeback).should be_falsey
       txn.can?(:finance_user, :chargeback).should be_truthy
 
       # reverse meaning of the above, should return the same
@@ -295,11 +295,11 @@ describe Bali do
 
       txn = My::Transaction.new
       txn.is_settled = false
-      txn.cant?(:finance_user, :chargeback).should be_truthy
+      txn.cannot?(:finance_user, :chargeback).should be_truthy
       txn.can?(:finance_user, :chargeback).should be_falsey
-      
+
       txn.is_settled = true
-      txn.cant?(:finance_user, :chargeback).should be_falsey
+      txn.cannot?(:finance_user, :chargeback).should be_falsey
       txn.can?(:finance_user, :chargeback).should be_truthy
     end
 
@@ -329,7 +329,7 @@ describe Bali do
       rc.rules_for(:general_user).get_rule(:can, :show).class.should == Bali::Rule
       Bali::Integrators::Rule.rule_class_for(:transaction).should be_nil
 
-      Bali.map_rules do 
+      Bali.map_rules do
         rules_for My::Transaction, as: :transaction do
           describe :general_user, can: :show
         end
@@ -342,7 +342,7 @@ describe Bali do
       Bali::Integrators::Rule.rule_class_for(My::Transaction).should == rc
     end
 
-    it "should redefine rule class if map_rules is called" do 
+    it "should redefine rule class if map_rules is called" do
       expect(Bali::Integrators::Rule.rule_classes.size).to eq(0)
       Bali.map_rules do
         rules_for My::Transaction, as: :transaction do
@@ -355,7 +355,7 @@ describe Bali do
         .rules.size).to eq(3)
 
       Bali.map_rules do
-        rules_for My::Transaction, as: :transaction do 
+        rules_for My::Transaction, as: :transaction do
           describe :general_user, can: :show
           describe :finance_user, can: [:update, :delete, :edit]
         end
@@ -382,5 +382,5 @@ describe Bali do
       expect(rc.rules_for(:general_user).get_rule(:can, :delete).has_decider?)
         .to eq(true)
     end
-  end # main module 
+  end # main module
 end

--- a/spec/foundations_spec.rb
+++ b/spec/foundations_spec.rb
@@ -79,9 +79,9 @@ describe Bali::RuleGroup do
         My::Transaction.respond_to?(:can?).should == true
       end
 
-      it "can responds to cant?" do
+      it "can responds to cannot?" do
         transaction = My::Transaction.new
-        expect(transaction.respond_to?(:cant?)).to eq true
+        expect(transaction.respond_to?(:cannot?)).to eq true
         transaction.class.ancestors.include?(Bali::Objector).should be_truthy
 
         # class-level question too
@@ -144,8 +144,8 @@ describe Bali::Rule do
     rule.operation.should == :delete
     rule.decider.should be_nil
 
-    rule = Bali::Rule.new(:cant, :delete)
-    rule.auth_val.should == :cant
+    rule = Bali::Rule.new(:cannot, :delete)
+    rule.auth_val.should == :cannot
     rule.operation.should == :delete
     rule.decider.should be_nil
   end
@@ -171,7 +171,7 @@ describe Bali::Rule do
     it "can only be either can or cant type" do
       expect {Bali::Rule.new(:xyz, :delete) }.to raise_error(Bali::DslError)
       expect {Bali::Rule.new(:can, :delete) }.to_not raise_error
-      expect {Bali::Rule.new(:cant, :delete)}.to_not raise_error
+      expect {Bali::Rule.new(:cannot, :delete)}.to_not raise_error
     end
     context "cant-type rule" do
       let(:rule) { Bali::Rule.new(:cant, :delete) }

--- a/spec/objections_spec.rb
+++ b/spec/objections_spec.rb
@@ -8,9 +8,9 @@ describe "Model objections" do
     My::Employee.can?(:undefined_subtarget, :new).should be_falsey
   end
 
-  it "should return true to cant? for undefined rule class" do 
+  it "should return true to cannot? for undefined rule class" do
     Bali::Integrators::Rule.rule_class_for(My::Employee).should be_nil
-    My::Employee.cant?(:undefined_subtarget, :new).should be_truthy
+    My::Employee.cannot?(:undefined_subtarget, :new).should be_truthy
   end
 
   it "should return false to can? for undefined rule group" do
@@ -24,7 +24,7 @@ describe "Model objections" do
     My::Transaction.can?(:undefined_subtarget, :new).should be_falsey
   end
 
-  it "should return true to cant? for undefined rule group" do
+  it "should return true to cannot? for undefined rule group" do
     Bali.map_rules do
       rules_for My::Transaction do
       end
@@ -32,7 +32,7 @@ describe "Model objections" do
 
     Bali::Integrators::Rule.rule_class_for(My::Transaction).class.should == Bali::RuleClass
     Bali::Integrators::Rule.rule_group_for(My::Transaction, :undefined_subtarget).should be_nil
-    My::Transaction.cant?(:undefined_subtarget, :new).should be_truthy
+    My::Transaction.cannot?(:undefined_subtarget, :new).should be_truthy
   end
 
   RSpec.shared_examples "objector" do
@@ -41,9 +41,9 @@ describe "Model objections" do
       My::Transaction.can?(:general_user, :delete).should be_falsey
     end
 
-    it "can asnwer to cant? on a class" do
-      My::Transaction.cant?(:supreme_user, :save).should be_falsey
-      My::Transaction.cant?(:general_user, :new).should be_truthy
+    it "can asnwer to cannot? on a class" do
+      My::Transaction.cannot?(:supreme_user, :save).should be_falsey
+      My::Transaction.cannot?(:general_user, :new).should be_truthy
     end
   end
 
@@ -51,8 +51,8 @@ describe "Model objections" do
     it "can query" do
       Bali.map_rules do
         roles_for My::Employee, :roles
-        rules_for My::Transaction do 
-          describe :admin, :general_user do 
+        rules_for My::Transaction do
+          describe :admin, :general_user do
             can :show, :edit, :new
           end
           describe :general_user do
@@ -76,7 +76,7 @@ describe "Model objections" do
       txn.can?(:admin, :delete).should be_truthy
       txn.can?(me, :delete).should be_truthy
       expect { txn.can!(:admin, :delete) }.to_not raise_error
-      expect { txn.can!(me, :delete) }.to_not raise_error 
+      expect { txn.can!(me, :delete) }.to_not raise_error
 
       me.roles = [:admin, :general_user]
       txn.can?(me, :delete).should be_truthy
@@ -86,15 +86,15 @@ describe "Model objections" do
       expect { txn.can!(me, :copy) }.to_not raise_error
       expect { txn.can!(me, :edit) }.to_not raise_error
     end
-    
-    it "can query rule having if decider" do 
-      Bali.map_rules do 
+
+    it "can query rule having if decider" do
+      Bali.map_rules do
         roles_for My::Employee, :roles
-        rules_for My::Transaction do 
-          describe :admin, :general_user do 
+        rules_for My::Transaction do
+          describe :admin, :general_user do
             can :show
           end
-          describe :general_user do 
+          describe :general_user do
             can :edit, if: proc { |record, user| user.exp_years > 3 }
             can :cancel, if: proc { |record, user| !record.is_settled? && user.exp_years > 3 }
           end
@@ -106,38 +106,38 @@ describe "Model objections" do
       me.roles = [:general_user]
 
       txn.can?(me, :show).should be_truthy
-      txn.cant?(me, :show).should be_falsey
+      txn.cannot?(me, :show).should be_falsey
       expect { txn.can!(me, :show) }.to_not raise_error
-      expect { txn.cant!(me, :show) }.to raise_error(Bali::AuthorizationError)
+      expect { txn.cannot!(me, :show) }.to raise_error(Bali::AuthorizationError)
 
       me.exp_years = 2
       txn.can?(me, :edit).should be_falsey
-      txn.cant?(me, :edit).should be_truthy
+      txn.cannot?(me, :edit).should be_truthy
       expect { txn.can!(me, :edit) }.to raise_error(Bali::AuthorizationError)
-      expect { txn.cant!(me, :edit) }.to_not raise_error
+      expect { txn.cannot!(me, :edit) }.to_not raise_error
 
       me.exp_years = 3
       txn.can?(me, :edit).should be_falsey
-      txn.cant?(me, :edit).should be_truthy
+      txn.cannot?(me, :edit).should be_truthy
       expect { txn.can!(me, :edit) }.to raise_error(Bali::AuthorizationError)
-      expect { txn.cant!(me, :edit) }.to_not raise_error
+      expect { txn.cannot!(me, :edit) }.to_not raise_error
 
       me.exp_years = 4
       txn.can?(me, :edit).should be_truthy
-      txn.cant?(me, :edit).should be_falsey
+      txn.cannot?(me, :edit).should be_falsey
       expect { txn.can!(me, :edit) }.to_not raise_error
-      expect { txn.cant!(me, :edit) }.to raise_error(Bali::AuthorizationError)
+      expect { txn.cannot!(me, :edit) }.to raise_error(Bali::AuthorizationError)
 
       txn.can?(me, :cancel).should be_truthy
-      txn.cant?(me, :cancel).should be_falsey
+      txn.cannot?(me, :cancel).should be_falsey
       expect { txn.can!(me, :cancel) }.to_not raise_error
-      expect { txn.cant!(me, :cancel) }.to raise_error(Bali::AuthorizationError)
+      expect { txn.cannot!(me, :cancel) }.to raise_error(Bali::AuthorizationError)
 
       txn.is_settled = true
       txn.can?(me, :cancel).should be_falsey
       expect { txn.can!(me, :cancel) }.to raise_error(Bali::AuthorizationError)
-      txn.cant?(me, :cancel).should be_truthy
-      expect { txn.cant!(me, :cancel) }.to_not raise_error
+      txn.cannot?(me, :cancel).should be_truthy
+      expect { txn.cannot!(me, :cancel) }.to_not raise_error
 
       me.roles = :admin
       me.exp_years = 0
@@ -145,44 +145,44 @@ describe "Model objections" do
       txn.can?(me, :show).should be_truthy
       txn.can?(me, :edit).should be_truthy
       txn.can?(me, :cancel).should be_truthy
-      txn.cant?(me, :show).should be_falsey
-      txn.cant?(me, :edit).should be_falsey
-      txn.cant?(me, :cancel).should be_falsey
+      txn.cannot?(me, :show).should be_falsey
+      txn.cannot?(me, :edit).should be_falsey
+      txn.cannot?(me, :cancel).should be_falsey
 
-      expect { txn.can!(me, :show) }.to_not raise_error 
-      expect { txn.can!(me, :edit) }.to_not raise_error 
-      expect { txn.can!(me, :cancel) }.to_not raise_error 
-      expect { txn.cant!(me, :show) }.to raise_error(Bali::AuthorizationError)
-      expect { txn.cant!(me, :edit) }.to raise_error(Bali::AuthorizationError) 
-      expect { txn.cant!(me, :cancel) }.to raise_error(Bali::AuthorizationError)
+      expect { txn.can!(me, :show) }.to_not raise_error
+      expect { txn.can!(me, :edit) }.to_not raise_error
+      expect { txn.can!(me, :cancel) }.to_not raise_error
+      expect { txn.cannot!(me, :show) }.to raise_error(Bali::AuthorizationError)
+      expect { txn.cannot!(me, :edit) }.to raise_error(Bali::AuthorizationError)
+      expect { txn.cannot!(me, :cancel) }.to raise_error(Bali::AuthorizationError)
 
 
       me.roles = [:general_user, :admin]
       txn.can?(me, :show).should be_truthy
       txn.can?(me, :edit).should be_truthy
       txn.can?(me, :cancel).should be_truthy
-      txn.cant?(me, :show).should be_falsey
-      txn.cant?(me, :edit).should be_falsey
-      txn.cant?(me, :cancel).should be_falsey
+      txn.cannot?(me, :show).should be_falsey
+      txn.cannot?(me, :edit).should be_falsey
+      txn.cannot?(me, :cancel).should be_falsey
 
-      expect { txn.can!(me, :show) }.to_not raise_error 
-      expect { txn.can!(me, :edit) }.to_not raise_error 
-      expect { txn.can!(me, :cancel) }.to_not raise_error 
-      expect { txn.cant!(me, :show) }.to raise_error(Bali::AuthorizationError) 
-      expect { txn.cant!(me, :edit) }.to raise_error(Bali::AuthorizationError) 
-      expect { txn.cant!(me, :cancel) }.to raise_error(Bali::AuthorizationError) 
+      expect { txn.can!(me, :show) }.to_not raise_error
+      expect { txn.can!(me, :edit) }.to_not raise_error
+      expect { txn.can!(me, :cancel) }.to_not raise_error
+      expect { txn.cannot!(me, :show) }.to raise_error(Bali::AuthorizationError)
+      expect { txn.cannot!(me, :edit) }.to raise_error(Bali::AuthorizationError)
+      expect { txn.cannot!(me, :cancel) }.to raise_error(Bali::AuthorizationError)
     end
 
-    it "can query rule having unless decider" do 
-      Bali.map_rules do 
+    it "can query rule having unless decider" do
+      Bali.map_rules do
         roles_for My::Employee, :roles
-        rules_for My::Transaction do 
-          describe :general_user do 
+        rules_for My::Transaction do
+          describe :general_user do
             can :show
-            can :edit, unless: proc { |record, user| 
+            can :edit, unless: proc { |record, user|
               (user.exp_years <= 3)
             }
-            can :cancel, unless: proc { |record, user| 
+            can :cancel, unless: proc { |record, user|
               record.is_settled? && (user.exp_years > 3)
             }
           end
@@ -194,23 +194,23 @@ describe "Model objections" do
       me.roles = [:general_user]
 
       txn.can?(me, :show).should be_truthy
-      txn.cant?(me, :show).should be_falsey
+      txn.cannot?(me, :show).should be_falsey
 
       me.exp_years = 2
       txn.can?(me, :edit).should be_falsey
-      txn.cant?(me, :edit).should be_truthy
+      txn.cannot?(me, :edit).should be_truthy
       me.exp_years = 3
       txn.can?(me, :edit).should be_falsey
-      txn.cant?(me, :edit).should be_truthy
+      txn.cannot?(me, :edit).should be_truthy
       me.exp_years = 4
       txn.can?(me, :edit).should be_truthy
-      txn.cant?(me, :edit).should be_falsey
+      txn.cannot?(me, :edit).should be_falsey
 
       txn.can?(me, :cancel).should be_truthy
-      txn.cant?(me, :cancel).should be_falsey
+      txn.cannot?(me, :cancel).should be_falsey
       txn.is_settled = true
       txn.can?(me, :cancel).should be_falsey
-      txn.cant?(me, :cancel).should be_truthy
+      txn.cannot?(me, :cancel).should be_truthy
 
       me.roles = :admin
       me.exp_years = 0
@@ -218,103 +218,103 @@ describe "Model objections" do
       txn.can?(me, :show).should be_truthy
       txn.can?(me, :edit).should be_truthy
       txn.can?(me, :cancel).should be_truthy
-      txn.cant?(me, :show).should be_falsey
-      txn.cant?(me, :edit).should be_falsey
-      txn.cant?(me, :cancel).should be_falsey
+      txn.cannot?(me, :show).should be_falsey
+      txn.cannot?(me, :edit).should be_falsey
+      txn.cannot?(me, :cancel).should be_falsey
 
       me.roles = [:general_user, :admin]
       txn.can?(me, :show).should be_truthy
       txn.can?(me, :edit).should be_truthy
       txn.can?(me, :cancel).should be_truthy
-      txn.cant?(me, :show).should be_falsey
-      txn.cant?(me, :edit).should be_falsey
-      txn.cant?(me, :cancel).should be_falsey
+      txn.cannot?(me, :show).should be_falsey
+      txn.cannot?(me, :edit).should be_falsey
+      txn.cannot?(me, :cancel).should be_falsey
     end
   end
 
-  context "Abstractly defined rules" do 
-    before(:each) do 
+  context "Abstractly defined rules" do
+    before(:each) do
       Bali.clear_rules
-      Bali.map_rules do 
+      Bali.map_rules do
         rules_for My::Transaction, as: :transaction do
           describe(:supreme_user) { can_all }
           describe(:admin_user) do
             can_all
-            cant :delete
+            cannot :delete
           end
-          describe(:general_user) do 
-            cant_all
+          describe(:general_user) do
+            cannot_all
             can :view
             can :print, if: proc { |txn| txn.is_settled? }
           end
         end
       end
     end
-    
+
     describe My::Transaction do
       it_behaves_like "objector"
 
-      context "admin user" do 
-        it "can do anything, but not delete" do 
+      context "admin user" do
+        it "can do anything, but not delete" do
           txn.can?(:admin_user, :cancel).should be_truthy
           txn.can?(:admin_user, :delete).should be_falsey
           txn.can?(:admin_user, :create).should be_truthy
           txn.can?(:admin_user, :update).should be_truthy
 
-          txn.cant?(:admin_user, :cancel).should be_falsey
-          txn.cant?(:admin_user, :delete).should be_truthy
-          txn.cant?(:admin_user, :create).should be_falsey
-          txn.cant?(:admin_user, :update).should be_falsey
+          txn.cannot?(:admin_user, :cancel).should be_falsey
+          txn.cannot?(:admin_user, :delete).should be_truthy
+          txn.cannot?(:admin_user, :create).should be_falsey
+          txn.cannot?(:admin_user, :update).should be_falsey
         end
       end
 
-      context "supreme user" do 
+      context "supreme user" do
         it "can do anything" do
           txn.can?(:supreme_user, :cancel).should be_truthy
           txn.can?(:supreme_user, :delete).should be_truthy
           txn.can?(:supreme_user, :create).should be_truthy
           txn.can?(:supreme_user, :update).should be_truthy
 
-          txn.cant?(:supreme_user, :cancel).should be_falsey
-          txn.cant?(:supreme_user, :delete).should be_falsey
-          txn.cant?(:supreme_user, :create).should be_falsey
-          txn.cant?(:supreme_user, :update).should be_falsey
+          txn.cannot?(:supreme_user, :cancel).should be_falsey
+          txn.cannot?(:supreme_user, :delete).should be_falsey
+          txn.cannot?(:supreme_user, :create).should be_falsey
+          txn.cannot?(:supreme_user, :update).should be_falsey
         end
       end
 
-      context "general user" do 
+      context "general user" do
         it "cannot do anything" do
           txn.can?(:general_user, :cancel).should be_falsey
           txn.can?(:general_user, :delete).should be_falsey
           txn.can?(:general_user, :create).should be_falsey
           txn.can?(:general_user, :update).should be_falsey
 
-          txn.cant?(:general_user, :cancel).should be_truthy
-          txn.cant?(:general_user, :delete).should be_truthy
-          txn.cant?(:general_user, :create).should be_truthy
-          txn.cant?(:general_user, :update).should be_truthy
+          txn.cannot?(:general_user, :cancel).should be_truthy
+          txn.cannot?(:general_user, :delete).should be_truthy
+          txn.cannot?(:general_user, :create).should be_truthy
+          txn.cannot?(:general_user, :update).should be_truthy
         end
 
         it "can view transaction" do
           txn.can?(:general_user, :view).should be_truthy
-          txn.cant?(:general_user, :view).should be_falsey
+          txn.cannot?(:general_user, :view).should be_falsey
         end
 
         it "can print if transaction is settled" do
           txn.is_settled = true
           txn.can?(:general_user, :print).should be_truthy
-          txn.cant?(:general_user, :print).should be_falsey
+          txn.cannot?(:general_user, :print).should be_falsey
         end
 
         it "can't print if transaction is not settled" do
           txn.is_settled = false
           txn.can?(:general_user, :print).should be_falsey
-          txn.cant?(:general_user, :print).should be_truthy
+          txn.cannot?(:general_user, :print).should be_truthy
         end
       end
     end
   end
-  
+
   context "Well defined rules" do
     before(:each) do
       Bali.map_rules do
@@ -322,20 +322,20 @@ describe "Model objections" do
           describe(:supreme_user) { can_all }
           describe :admin_user do
             can_all
-            can :cancel, 
-              if: proc { |record| record.payment_channel == "CREDIT_CARD" && 
+            can :cancel,
+              if: proc { |record| record.payment_channel == "CREDIT_CARD" &&
                                   !record.is_settled? }
           end
           describe :general_user, :finance_user, :monitoring do
             can :ask
           end
-          describe "general user", can: [:view, :edit, :update], cant: [:delete]
+          describe "general user", can: [:view, :edit, :update], cannot: [:delete]
           describe "finance user" do
             can :update, :delete, :edit
             can :delete, if: proc { |record| record.is_settled? }
           end # finance_user description
           describe :monitoring do
-            cant_all
+            cannot_all
             can :monitor
           end
           describe nil do
@@ -353,21 +353,21 @@ describe "Model objections" do
           roles1, roles2 = [nil, :supreme_user], [:supreme_user, nil]
 
           txn.can?(nil, :monitor).should be_falsey
-          txn.cant?(nil, :monitor).should be_truthy
+          txn.cannot?(nil, :monitor).should be_truthy
           txn.can?(roles1, :monitor).should be_truthy
           txn.can?(roles2, :monitor).should be_truthy
-          txn.cant?(roles1, :monitor).should be_falsey
-          txn.cant?(roles2, :monitor).should be_falsey
+          txn.cannot?(roles1, :monitor).should be_falsey
+          txn.cannot?(roles2, :monitor).should be_falsey
 
           txn.can?(roles1, :delete).should be_truthy
           txn.can?(roles2, :delete).should be_truthy
           txn.can?(roles1, :cancel).should be_truthy
           txn.can?(roles2, :cancel).should be_truthy
 
-          txn.cant?(roles1, :delete).should be_falsey
-          txn.cant?(roles2, :delete).should be_falsey
-          txn.cant?(roles1, :cancel).should be_falsey
-          txn.cant?(roles2, :cancel).should be_falsey
+          txn.cannot?(roles1, :delete).should be_falsey
+          txn.cannot?(roles2, :delete).should be_falsey
+          txn.cannot?(roles1, :cancel).should be_falsey
+          txn.cannot?(roles2, :cancel).should be_falsey
         end
 
         it "allows user with role of admin and finance user to delete regardless whether transaction is settled or not" do
@@ -375,17 +375,17 @@ describe "Model objections" do
 
           txn.is_settled = false
           txn.can?(:admin_user, :delete).should be_truthy
-          txn.cant?(:admin_user, :delete).should be_falsey
+          txn.cannot?(:admin_user, :delete).should be_falsey
           txn.can?(:finance_user, :delete).should be_falsey
-          txn.cant?(:finance_user, :delete).should be_truthy
+          txn.cannot?(:finance_user, :delete).should be_truthy
 
           [true, false].each do |settlement_status|
             txn.is_settled = settlement_status
 
             txn.can?(roles1, :delete).should be_truthy
             txn.can?(roles2, :delete).should be_truthy
-            txn.cant?(roles1, :delete).should be_falsey
-            txn.cant?(roles2, :delete).should be_falsey
+            txn.cannot?(roles1, :delete).should be_falsey
+            txn.cannot?(roles2, :delete).should be_falsey
           end
         end
 
@@ -395,27 +395,27 @@ describe "Model objections" do
           txn.is_settled = true
           txn.can?(roles1, :delete).should be_truthy
           txn.can?(roles2, :delete).should be_truthy
-          txn.cant?(roles1, :delete).should be_falsey
-          txn.cant?(roles2, :delete).should be_falsey
+          txn.cannot?(roles1, :delete).should be_falsey
+          txn.cannot?(roles2, :delete).should be_falsey
 
           txn.is_settled = false
           txn.can?(roles1, :delete).should be_falsey
           txn.can?(roles2, :delete).should be_falsey
-          txn.cant?(roles1, :delete).should be_truthy
-          txn.cant?(roles2, :delete).should be_truthy
+          txn.cannot?(roles1, :delete).should be_truthy
+          txn.cannot?(roles2, :delete).should be_truthy
         end
 
         it "allows user with role of finance and monitoring to monitor" do
           txn.can?(:finance_user, :monitor).should be_falsey
           txn.can?(:monitoring, :monitor).should be_truthy
-          txn.cant?(:finance_user, :monitor).should be_truthy
-          txn.cant?(:monitoring, :monitor).should be_falsey
+          txn.cannot?(:finance_user, :monitor).should be_truthy
+          txn.cannot?(:monitoring, :monitor).should be_falsey
 
           txn.can?([:monitoring, :finance_user], :monitor).should be_truthy
           txn.can?([:finance_user, :monitoring], :monitor).should be_truthy
 
-          txn.cant?([:monitoring, :finance_user], :monitor).should be_falsey
-          txn.cant?([:finance_user, :monitoring], :monitor).should be_falsey
+          txn.cannot?([:monitoring, :finance_user], :monitor).should be_falsey
+          txn.cannot?([:finance_user, :monitoring], :monitor).should be_falsey
         end
       end
 
@@ -433,7 +433,7 @@ describe "Model objections" do
       context "general user" do
         it "can ask" do
           txn.can?(:general_user, :ask).should be_truthy
-          txn.cant?("general user", :ask).should be_falsey
+          txn.cannot?("general user", :ask).should be_falsey
         end
 
         it "can view transaction" do
@@ -450,7 +450,7 @@ describe "Model objections" do
 
         it "cannot delete transaction" do
           txn.can?("general user", :delete).should be_falsey
-          Bali::Integrators::Rule.rule_group_for(txn.class, "general user").get_rule(:cant, :delete)
+          Bali::Integrators::Rule.rule_group_for(txn.class, "general user").get_rule(:cannot, :delete)
             .class.should == Bali::Rule
         end
 
@@ -468,7 +468,7 @@ describe "Model objections" do
       context "finance user" do
         it "can ask" do
           txn.can?("finance user", :ask).should be_truthy
-          txn.cant?(:finance_user, :ask).should be_falsey
+          txn.cannot?(:finance_user, :ask).should be_falsey
         end
 
         it "can update and edit transaction" do
@@ -485,7 +485,7 @@ describe "Model objections" do
           txn.is_settled = true
           txn.can?(:finance_user, :delete).should be_truthy
         end
-      end    
+      end
 
       context "admin user" do
         it "can update and edit transaction" do
@@ -496,7 +496,7 @@ describe "Model objections" do
         it "can delete transation, whether settled or not" do
           txn.is_settled = false
           txn.can?(:admin_user, :delete).should be_truthy
-          
+
           txn.is_settled = true
           txn.can?(:admin_user, :delete).should be_truthy
         end
@@ -558,32 +558,32 @@ describe "Model objections" do
         expect { My::Transaction.can!(nil, :save) }.to raise_error(Bali::AuthorizationError)
       end
 
-      it "can answer to cant?" do
-        My::Transaction.cant?(:supreme_user, :delete).should be_falsey
-        My::Transaction.cant?(:admin_user, :delete).should be_falsey
-        My::Transaction.cant?(:general_user, :edit).should be_falsey
-        My::Transaction.cant?(:general_user, :view).should be_falsey
-        My::Transaction.cant?(:general_user, :delete).should be_truthy
-        My::Transaction.cant?(:finance_user, :update).should be_falsey
-        My::Transaction.cant?(:finance_user, :new).should be_truthy
-        My::Transaction.cant?(:monitoring, :read).should be_truthy
-        My::Transaction.cant?(:monitoring, :monitor).should be_falsey
-        My::Transaction.cant?(nil, :view).should be_falsey
-        My::Transaction.cant?(nil, :save).should be_truthy
+      it "can answer to cannot?" do
+        My::Transaction.cannot?(:supreme_user, :delete).should be_falsey
+        My::Transaction.cannot?(:admin_user, :delete).should be_falsey
+        My::Transaction.cannot?(:general_user, :edit).should be_falsey
+        My::Transaction.cannot?(:general_user, :view).should be_falsey
+        My::Transaction.cannot?(:general_user, :delete).should be_truthy
+        My::Transaction.cannot?(:finance_user, :update).should be_falsey
+        My::Transaction.cannot?(:finance_user, :new).should be_truthy
+        My::Transaction.cannot?(:monitoring, :read).should be_truthy
+        My::Transaction.cannot?(:monitoring, :monitor).should be_falsey
+        My::Transaction.cannot?(nil, :view).should be_falsey
+        My::Transaction.cannot?(nil, :save).should be_truthy
       end
 
-      it "can answer to cant!" do
-        expect { My::Transaction.cant!(:supreme_user, :delete) }.to raise_error(Bali::AuthorizationError)
-        expect { My::Transaction.cant!(:admin_user, :delete) }.to raise_error(Bali::AuthorizationError)
-        expect { My::Transaction.cant!(:general_user, :edit) }.to raise_error(Bali::AuthorizationError)
-        expect { My::Transaction.cant!(:general_user, :view) }.to raise_error(Bali::AuthorizationError)
-        expect { My::Transaction.cant!(:general_user, :delete) }.to_not raise_error
-        expect { My::Transaction.cant!(:finance_user, :update) }.to raise_error(Bali::AuthorizationError)
-        expect { My::Transaction.cant!(:finance_user, :new) }.to_not raise_error
-        expect { My::Transaction.cant!(:monitoring, :read) }.to_not raise_error
-        expect { My::Transaction.cant!(:monitoring, :monitor) }.to raise_error(Bali::AuthorizationError)
-        expect { My::Transaction.cant!(nil, :view) }.to raise_error(Bali::AuthorizationError)
-        expect { My::Transaction.cant!(nil, :save) }.to_not raise_error        
+      it "can answer to cannot!" do
+        expect { My::Transaction.cannot!(:supreme_user, :delete) }.to raise_error(Bali::AuthorizationError)
+        expect { My::Transaction.cannot!(:admin_user, :delete) }.to raise_error(Bali::AuthorizationError)
+        expect { My::Transaction.cannot!(:general_user, :edit) }.to raise_error(Bali::AuthorizationError)
+        expect { My::Transaction.cannot!(:general_user, :view) }.to raise_error(Bali::AuthorizationError)
+        expect { My::Transaction.cannot!(:general_user, :delete) }.to_not raise_error
+        expect { My::Transaction.cannot!(:finance_user, :update) }.to raise_error(Bali::AuthorizationError)
+        expect { My::Transaction.cannot!(:finance_user, :new) }.to_not raise_error
+        expect { My::Transaction.cannot!(:monitoring, :read) }.to_not raise_error
+        expect { My::Transaction.cannot!(:monitoring, :monitor) }.to raise_error(Bali::AuthorizationError)
+        expect { My::Transaction.cannot!(nil, :view) }.to raise_error(Bali::AuthorizationError)
+        expect { My::Transaction.cannot!(nil, :save) }.to_not raise_error
       end
 
       it "raises exception with information on can! on an unauthorized access" do
@@ -602,7 +602,7 @@ describe "Model objections" do
         user.roles = [:general_user]
         begin
           txn.can!(user, :delete)
-        rescue => e 
+        rescue => e
           e.class.should == Bali::AuthorizationError
           e.auth_level.should == :can
           e.role.should == :general_user
@@ -612,12 +612,12 @@ describe "Model objections" do
         end
       end
 
-      it "raises exception with information on cant! on an unauthorized access" do
+      it "raises exception with information on cannot! on an unauthorized access" do
         begin
-          My::Transaction.cant!(:monitoring, :monitor)
-        rescue => e 
+          My::Transaction.cannot!(:monitoring, :monitor)
+        rescue => e
           e.class.should == Bali::AuthorizationError
-          e.auth_level.should == :cant
+          e.auth_level.should == :cannot
           e.role.should == :monitoring
           e.subtarget.should == :monitoring
           e.operation.should == :monitor
@@ -627,10 +627,10 @@ describe "Model objections" do
         user = My::Employee.new
         user.roles = [:general_user]
         begin
-          txn.cant!(user, :delete)
-        rescue => e 
+          txn.cannot!(user, :delete)
+        rescue => e
           e.class.should == Bali::AuthorizationError
-          e.auth_level.should == :cant
+          e.auth_level.should == :cannot
           e.role.should == :monitoring_user
           e.subtarget.should == user
           e.operation.should == :monitor
@@ -644,26 +644,26 @@ describe "Model objections" do
     Bali.map_rules do
       rules_for My::Transaction do
         describe :user do
-          cant_all
+          cannot_all
           can :show
 
-          cant :edit
+          cannot :edit
           can :edit
 
           can :update
-          cant :update
+          cannot :update
         end
       end
     end
 
     txn = My::Transaction.new
     txn.can?(:user, :show).should be_truthy
-    txn.cant?(:user, :show).should be_falsey
+    txn.cannot?(:user, :show).should be_falsey
 
     txn.can?(:user, :edit).should be_truthy
-    txn.cant?(:user, :edit).should be_falsey
+    txn.cannot?(:user, :edit).should be_falsey
 
     txn.can?(:user, :update).should be_falsey
-    txn.cant?(:user, :update).should be_truthy
+    txn.cannot?(:user, :update).should be_truthy
   end
 end


### PR DESCRIPTION
Spec properly using cannot, cannot_all, cannot? cannot! instead of its to-be deprecated variants
