### PR TITLE
Removing alias for target

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Rule in Bali is the law determining whether a user (called `subtarget`) can do o
 
 ```ruby
   Bali.map_rules do
-    rules_for My::Transaction, as: :transaction do
+    rules_for My::Transaction do
       describe(:supreme_user) { can_all }
       describe :admin_user do
         can_all
@@ -55,8 +55,6 @@ Rule in Bali is the law determining whether a user (called `subtarget`) can do o
     end # rules_for
   end
 ```
-
-You may or may not assign an alias name (`as`). Make sure to keep it unique had you decided to give alias name to your rules group.
 
 It is also possible for a rule to be defined for multiple subtarget at once:
 

--- a/lib/bali.rb
+++ b/lib/bali.rb
@@ -13,12 +13,6 @@ module Bali
   # mapping class to a RuleClass
   RULE_CLASS_MAP = {}
 
-  # from symbol to full class name
-  ALIASED_RULE_CLASS_MAP = {}
-
-  # from full class name to symbol
-  REVERSE_ALIASED_RULE_CLASS_MAP = {}
-
   # {
   #   User: :roles,
   #   AdminUser: :admin_roles
@@ -38,8 +32,6 @@ module Bali
 
   def clear_rules
     Bali::RULE_CLASS_MAP.clear
-    Bali::REVERSE_ALIASED_RULE_CLASS_MAP.clear
-    Bali::ALIASED_RULE_CLASS_MAP.clear
     true
   end
 end

--- a/lib/bali/dsl/map_rules_dsl.rb
+++ b/lib/bali/dsl/map_rules_dsl.rb
@@ -10,7 +10,6 @@ class Bali::MapRulesDsl
   def rules_for(target_class, target_alias_hash = {}, &block)
     @@lock.synchronize do
       self.current_rule_class = Bali::RuleClass.new(target_class)
-      self.current_rule_class.alias_name = target_alias_hash[:as] || target_alias_hash["as"]
 
       Bali::RulesForDsl.new(self).instance_eval(&block)
 

--- a/lib/bali/dsl/rules_for_dsl.rb
+++ b/lib/bali/dsl/rules_for_dsl.rb
@@ -33,13 +33,12 @@ class Bali::RulesForDsl
     end
 
     target_class = self.map_rules_dsl.current_rule_class.target_class
-    target_alias = self.map_rules_dsl.current_rule_class.alias_name
 
     subtargets.each do |subtarget|
       @@lock.synchronize do
         rule_group = self.current_rule_class.rules_for(subtarget)
         if rule_group.nil?
-          rule_group = Bali::RuleGroup.new(target_class, target_alias, subtarget)
+          rule_group = Bali::RuleGroup.new(target_class, subtarget)
         end
 
         self.current_rule_group = rule_group

--- a/lib/bali/foundations/rule/rule_class.rb
+++ b/lib/bali/foundations/rule/rule_class.rb
@@ -1,7 +1,6 @@
 # the parent of all Bali::RuleGroup.
 class Bali::RuleClass
   attr_reader :target_class
-  attr_accessor :alias_name
 
   attr_accessor :rule_groups
 

--- a/lib/bali/foundations/rule/rule_group.rb
+++ b/lib/bali/foundations/rule/rule_group.rb
@@ -2,9 +2,6 @@ class Bali::RuleGroup
   # the target class
   attr_accessor :target
 
-  # the alias name for the target
-  attr_accessor :alias_tgt
-
   # the user to which this rule group is applied
   attr_accessor :subtarget
 
@@ -28,9 +25,8 @@ class Bali::RuleGroup
     end
   end
 
-  def initialize(target, alias_tgt, subtarget)
+  def initialize(target, subtarget)
     self.target = target
-    self.alias_tgt = alias_tgt
     self.subtarget = Bali::RuleGroup.canon_name(subtarget)
 
     self.cans = {}

--- a/lib/bali/integrators/rules_integrator.rb
+++ b/lib/bali/integrators/rules_integrator.rb
@@ -6,14 +6,9 @@ module Bali::Integrators::Rule
   end
 
   def rule_class_for(target)
-    if target.is_a?(Symbol)
-      class_name = Bali::ALIASED_RULE_CLASS_MAP[target]
-      return class_name.nil? ? nil : rule_class_for(class_name)
-    else
-      raise Bali::DslError, "Target must be a class" unless target.is_a?(Class)
-      rule_class = Bali::RULE_CLASS_MAP[target.to_s]
-      return rule_class.nil? ? nil : rule_class
-    end
+    raise Bali::DslError, "Target must be a class" unless target.is_a?(Class)
+    rule_class = Bali::RULE_CLASS_MAP[target.to_s]
+    return rule_class.nil? ? nil : rule_class
   end
 
   # attempt to search the rule group, but if not exist, will return nil
@@ -32,16 +27,6 @@ module Bali::Integrators::Rule
       target = rule_class.target_class
 
       raise Bali::DslError, "Target must be a class" unless target.is_a?(Class)
-
-      # remove any previous association of rule
-      begin
-        last_associated_alias = Bali::REVERSE_ALIASED_RULE_CLASS_MAP[target]
-        if last_associated_alias
-          Bali::ALIASED_RULE_CLASS_MAP.delete(last_associated_alias)
-          Bali::REVERSE_ALIASED_RULE_CLASS_MAP.delete(target)
-          Bali::RULE_CLASS_MAP.delete(target)
-        end
-      end
 
       Bali::RULE_CLASS_MAP[target.to_s] = rule_class
       rule_class

--- a/lib/bali/integrators/rules_integrator.rb
+++ b/lib/bali/integrators/rules_integrator.rb
@@ -30,7 +30,6 @@ module Bali::Integrators::Rule
   def add_rule_class(rule_class)
     if rule_class.is_a?(Bali::RuleClass)
       target = rule_class.target_class
-      alias_target = rule_class.alias_name
 
       raise Bali::DslError, "Target must be a class" unless target.is_a?(Class)
 
@@ -42,12 +41,6 @@ module Bali::Integrators::Rule
           Bali::REVERSE_ALIASED_RULE_CLASS_MAP.delete(target)
           Bali::RULE_CLASS_MAP.delete(target)
         end
-      end
-
-      # if "as" is present
-      if alias_target.is_a?(Symbol)
-        Bali::ALIASED_RULE_CLASS_MAP[alias_target] = target
-        Bali::REVERSE_ALIASED_RULE_CLASS_MAP[target] = alias_target
       end
 
       Bali::RULE_CLASS_MAP[target.to_s] = rule_class

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -101,7 +101,7 @@ describe Bali do
     it "allows definition of rules per subtarget" do
       expect(Bali::Integrators::Rule.rule_classes.size).to eq(0)
       Bali.map_rules do
-        rules_for My::Transaction, as: :transaction do
+        rules_for My::Transaction do
           describe :general_user, can: :show
           describe :finance_user do
             can :update, :delete, :edit
@@ -306,7 +306,7 @@ describe Bali do
     it "can define nil rule group" do
       expect(Bali::Integrators::Rule.rule_classes.size).to eq(0)
       Bali.map_rules do
-        rules_for My::Transaction, as: :transaction do
+        rules_for My::Transaction do
           describe nil do
             can :view
           end
@@ -316,7 +316,7 @@ describe Bali do
       Bali::Integrators::Rule.rule_class_for(My::Transaction).class.should == Bali::RuleClass
     end
 
-    it "should allow rule group to be defined with or without alias" do
+    it "should allow rule group to be defined" do
       Bali.map_rules do
         rules_for My::Transaction do
           describe :general_user, can: :show
@@ -327,10 +327,10 @@ describe Bali do
       rc.class.should == Bali::RuleClass
       rc.rules_for(:general_user).class.should == Bali::RuleGroup
       rc.rules_for(:general_user).get_rule(:can, :show).class.should == Bali::Rule
-      Bali::Integrators::Rule.rule_class_for(:transaction).should be_nil
+      expect(Bali::Integrators::Rule.rule_class_for(My::Transaction)).to_not be_nil
 
       Bali.map_rules do
-        rules_for My::Transaction, as: :transaction do
+        rules_for My::Transaction do
           describe :general_user, can: :show
         end
       end
@@ -345,7 +345,7 @@ describe Bali do
     it "should redefine rule class if map_rules is called" do
       expect(Bali::Integrators::Rule.rule_classes.size).to eq(0)
       Bali.map_rules do
-        rules_for My::Transaction, as: :transaction do
+        rules_for My::Transaction do
           describe :general_user, can: [:update, :delete, :edit]
         end
       end
@@ -355,7 +355,7 @@ describe Bali do
         .rules.size).to eq(3)
 
       Bali.map_rules do
-        rules_for My::Transaction, as: :transaction do
+        rules_for My::Transaction do
           describe :general_user, can: :show
           describe :finance_user, can: [:update, :delete, :edit]
         end
@@ -370,7 +370,7 @@ describe Bali do
       Bali::Integrators::Rule.rule_classes.size.should == 0
 
       Bali.map_rules do
-        rules_for My::Transaction, as: :transaction do
+        rules_for My::Transaction do
           describe :general_user do |record|
             can :update, :delete
             can :delete, if: -> { record.is_settled? }

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -361,7 +361,7 @@ describe Bali do
         end
       end
       expect(Bali::Integrators::Rule.rule_classes.size).to eq(1)
-      rc = Bali::Integrators::Rule.rule_class_for(:transaction)
+      rc = Bali::Integrators::Rule.rule_class_for(My::Transaction)
       expect(rc.rules_for(:general_user).rules.size).to eq(1)
       expect(rc.rules_for(:finance_user).rules.size).to eq(3)
     end
@@ -378,7 +378,7 @@ describe Bali do
         end
       end
 
-      rc = Bali::Integrators::Rule.rule_class_for(:transaction)
+      rc = Bali::Integrators::Rule.rule_class_for(My::Transaction)
       expect(rc.rules_for(:general_user).get_rule(:can, :delete).has_decider?)
         .to eq(true)
     end

--- a/spec/foundations_spec.rb
+++ b/spec/foundations_spec.rb
@@ -30,7 +30,7 @@ describe Bali do
   it "should return Bali::RuleGroup if rule group is defined" do
     Bali::Integrators::Rule.add_rule_class(Bali::RuleClass.new(My::Transaction))
     rule_class = Bali::Integrators::Rule.rule_class_for(My::Transaction)
-    rule_class.add_rule_group(Bali::RuleGroup.new(My::Transaction, :transaction, :basic))
+    rule_class.add_rule_group(Bali::RuleGroup.new(My::Transaction, :basic))
     Bali::Integrators::Rule.rule_group_for(My::Transaction, :basic).class.should == Bali::RuleGroup
   end
 end
@@ -47,7 +47,7 @@ describe Bali::RuleClass do
   # non-nil rule group is rule group that is defined with proper-named group
   # such as :user, :admin, :supreme, etc
   it "can add non-nil rule group" do
-    rule_group = Bali::RuleGroup.new(My::Transaction, :transaction, :user)
+    rule_group = Bali::RuleGroup.new(My::Transaction, :user)
     rule_class = Bali::RuleClass.new(My::Transaction)
     expect { rule_class.add_rule_group(rule_group) }.to_not raise_error
     rule_class.rules_for(:user).class.should == Bali::RuleGroup
@@ -56,7 +56,7 @@ describe Bali::RuleClass do
   # nil rule group is for rule group that rules is targeting nil/un-authorized
   # un-authenticated or other un-available group for that matter: nil
   it "can add nil rule group" do
-    rule_group = Bali::RuleGroup.new(My::Transaction, :transaction, nil)
+    rule_group = Bali::RuleGroup.new(My::Transaction, nil)
     rule_class = Bali::RuleClass.new(My::Transaction)
     expect { rule_class.add_rule_group(rule_group) }.to_not raise_error
     rule_class.rules_for(nil).class.should == Bali::RuleGroup
@@ -113,11 +113,10 @@ describe Bali::RuleGroup do
   end # shared examples
 
   context "for :user" do
-    let(:rule_group) { Bali::RuleGroup.new(My::Transaction, :transaction, :user) }
+    let(:rule_group) { Bali::RuleGroup.new(My::Transaction, :user) }
 
     it "is creatable" do
       rule_group.target.should == My::Transaction
-      rule_group.alias_tgt.should == :transaction
       rule_group.subtarget.should == :user
     end
 
@@ -125,11 +124,10 @@ describe Bali::RuleGroup do
   end # context for :user
 
   context "for nil" do
-    let(:rule_group) { Bali::RuleGroup.new(My::Transaction, :transaction, nil) }
+    let(:rule_group) { Bali::RuleGroup.new(My::Transaction, nil) }
 
     it "is creatable" do
       rule_group.target.should == My::Transaction
-      rule_group.alias_tgt.should == :transaction
       rule_group.subtarget.should == nil
     end
 

--- a/spec/objections_spec.rb
+++ b/spec/objections_spec.rb
@@ -236,7 +236,7 @@ describe "Model objections" do
     before(:each) do
       Bali.clear_rules
       Bali.map_rules do
-        rules_for My::Transaction, as: :transaction do
+        rules_for My::Transaction do
           describe(:supreme_user) { can_all }
           describe(:admin_user) do
             can_all
@@ -318,7 +318,7 @@ describe "Model objections" do
   context "Well defined rules" do
     before(:each) do
       Bali.map_rules do
-        rules_for My::Transaction, as: :transaction do
+        rules_for My::Transaction do
           describe(:supreme_user) { can_all }
           describe :admin_user do
             can_all


### PR DESCRIPTION
Alias has become a maintenance nightmare. It makes the codebase unnecessarily ugly, on top of it being never used.

It was at first be made so as to make it easier for future development, to integrate ORM such as AR/Mongoid with Bali. In fact, that is so far fetched that the code really make the code base ugly.

I removed it.
