### PR TITLE
Clear rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,3 +60,4 @@
 1. `others` block would allow for rule definitions within it to be applied for all undefined subtargets of a target
 2. Fixing bug when roles_for of a user object retrieves `nil` as the user's role, it won't acknowledge that the user is indeed having `nil`-role and raising an error instead.
 3. Inherits rules by passing `:inherits` option when defining `rules_for`
+4. `clear_rules` within `describe` or `others` block to remove all inherited rules (or any rules previously defined) for that subtarget

--- a/lib/bali/dsl/map_rules_dsl.rb
+++ b/lib/bali/dsl/map_rules_dsl.rb
@@ -59,6 +59,10 @@ class Bali::MapRulesDsl
     raise Bali::DslError, "can_all block must be within describe block"
   end
 
+  def clear_rules
+    raise Bali::DslError, "clear_rules must be called within describe block"
+  end
+
   def cant_all(*params)
     puts "Deprecation Warning: declaring rules with cant_all will be deprecated on major release 3.0, use cannot instead"
     cannot_all *params

--- a/lib/bali/dsl/rules_for_dsl.rb
+++ b/lib/bali/dsl/rules_for_dsl.rb
@@ -101,7 +101,7 @@ class Bali::RulesForDsl
   end # others
 
   # to define can and cant is basically using this method
-  def process_auth_rules(auth_val, operations)
+  def bali_process_auth_rules(auth_val, operations)
     conditional_hash = nil
 
     # scan operations for options
@@ -129,14 +129,21 @@ class Bali::RulesForDsl
         self.current_rule_group.add_rule(rule)
       end
     end
-  end # process_auth_rules
+  end # bali_process_auth_rules
+
+  # clear all defined rules
+  def clear_rules
+    self.current_rule_group.clear_rules
+    self.current_rule_class.others_rule_group.clear_rules
+    true
+  end
 
   def can(*operations)
-    process_auth_rules(:can, operations)
+    bali_process_auth_rules(:can, operations)
   end
 
   def cannot(*operations)
-    process_auth_rules(:cannot, operations)
+    bali_process_auth_rules(:cannot, operations)
   end
 
   def cant(*operations)

--- a/lib/bali/foundations/rule/rule_group.rb
+++ b/lib/bali/foundations/rule/rule_group.rb
@@ -60,6 +60,11 @@ class Bali::RuleGroup
     end
   end
 
+  def clear_rules
+    self.cans = {}
+    self.cants = {}
+  end
+
   def get_rule(auth_val, operation)
     rule = nil
     case auth_val

--- a/spec/objections_spec.rb
+++ b/spec/objections_spec.rb
@@ -869,6 +869,48 @@ describe "Model objections" do
       end
     end
 
+    context "when clearing rules" do 
+      before do
+        Bali.map_rules do
+          rules_for My::SecuredTransaction, inherits: My::Transaction do
+            describe :general_user do
+              clear_rules
+              can :view
+            end
+          end
+        end
+      end
+
+      let(:stxn) { My::SecuredTransaction.new }
+
+      context "general user" do
+        it "can view transaction" do
+          expect(stxn.can?(:general_user, :view)).to be_truthy
+          expect(stxn.cannot?(:general_user, :view)).to be_falsey
+        end
+
+        it "canot ask" do
+          expect(stxn.can?(:general_user, :ask)).to be_falsey
+          expect(stxn.cannot?(:general_user, :ask)).to be_truthy
+        end
+
+        it "cannot edit" do
+          expect(stxn.can?(:general_user, :edit)).to be_falsey
+          expect(stxn.cannot?(:general_user, :edit)).to be_truthy
+        end
+
+        it "cannot delete" do
+          expect(stxn.can?(:general_user, :delete)).to be_falsey
+          expect(stxn.cannot?(:general_user, :delete)).to be_truthy
+        end
+
+        it "cannot edit" do
+          expect(stxn.can?(:general_user, :edit)).to be_falsey
+          expect(stxn.cannot?(:general_user, :edit)).to be_truthy
+        end
+      end
+    end
+
     context "cloned for My::SecuredTransaction" do
       before(:each) do
         Bali.map_rules do


### PR DESCRIPTION
`clear_rules` to clear all defined rules, especially useful for inherited rules
