### PR TITLE
Clear in context

### DIFF
--- a/lib/bali/dsl/rules_for_dsl.rb
+++ b/lib/bali/dsl/rules_for_dsl.rb
@@ -134,7 +134,6 @@ class Bali::RulesForDsl
   # clear all defined rules
   def clear_rules
     self.current_rule_group.clear_rules
-    self.current_rule_class.others_rule_group.clear_rules
     true
   end
 

--- a/lib/bali/foundations/rule/rule_class.rb
+++ b/lib/bali/foundations/rule/rule_class.rb
@@ -48,10 +48,14 @@ class Bali::RuleClass
     cloned_rc = Bali::RuleClass.new(target_class)
 
     rule_groups.each do |subtarget, rule_group|
-      cloned_rc.add_rule_group(rule_group.clone)
+      rule_group_clone = rule_group.clone
+      rule_group_clone.target = target_class
+      cloned_rc.add_rule_group(rule_group_clone)
     end
 
-    cloned_rc.others_rule_group = others_rule_group.clone
+    others_rule_group_clone = others_rule_group.clone
+    others_rule_group_clone.target = target_class
+    cloned_rc.others_rule_group = others_rule_group_clone
 
     cloned_rc
   end

--- a/lib/bali/version.rb
+++ b/lib/bali/version.rb
@@ -1,3 +1,3 @@
 module Bali
-  VERSION = "2.1.0"
+  VERSION = "2.2.0"
 end

--- a/spec/objections_spec.rb
+++ b/spec/objections_spec.rb
@@ -286,6 +286,12 @@ describe "Model objections" do
             can :index
           end # others
         end # rules_for
+
+        rules_for My::SecuredTransaction, inherits: My::Transaction do
+          describe :finance do
+            cannot_all
+          end
+        end
       end # map rules
     end # before
 
@@ -321,9 +327,16 @@ describe "Model objections" do
     end # admin user
 
     describe "finance user" do
-      it "should not allow to view" do
+      it "should not allow to view transaction" do
         expect(txn.can?(:finance, :view)).to be_falsey
         expect(txn.cannot?(:finance, :view)).to be_truthy
+      end
+
+      it "should not allow finance to view secured transaction" do
+        stxn = My::SecuredTransaction.new
+        stxn.is_settled = true
+        expect(stxn.can?(:finance, :view)).to be_falsey
+        expect(stxn.cannot?(:finance, :view)).to be_truthy
       end
 
       it "should allow finance to print" do

--- a/spec/print_spec.rb
+++ b/spec/print_spec.rb
@@ -26,6 +26,7 @@ describe "Printing Bali Rules" do
         end
       end # rules for My::SecuredTransaction
     end # map rules
+
     output = %Q{===== My::Transaction =====
 
       Supreme_user, can all: true, cannot all: false
@@ -59,18 +60,22 @@ describe "Printing Bali Rules" do
       Admin, can all: true, cannot all: false
       --------------------------------------------------------------------------------
         1. Admin can do anything except if explicitly stated otherwise
-        2. Admin cannot delete My::Transaction
+        2. Admin cannot delete My::SecuredTransaction
 
       Finance, can all: false, cannot all: false
       --------------------------------------------------------------------------------
-        1. Finance can view My::Transaction
+        1. Finance can view My::SecuredTransaction
+
+      Others, can all: false, cannot all: false
+      --------------------------------------------------------------------------------
+        1. Others can view My::SecuredTransaction, with condition
 
 
 
 
 
-Printed at 26-09-2015 12:09PM +07:00}
-
+Printed at 26-09-2015 12:58PM +07:00}
+    
     expected_output_without_printed_at = output.gsub(/Printed.*/i, "")
     bali_output = Bali::Printer.pretty_print 
     bali_output_without_printed_at = bali_output.gsub(/Printed.*/, "")
@@ -90,7 +95,7 @@ Printed at 26-09-2015 12:09PM +07:00}
       end
     end
 
-    expected_output = "===== My::Transaction =====\n\n      General_user, can all: false, cannot all: false\n      --------------------------------------------------------------------------------\n        1. General_user can edit My::Transaction\n        2. General_user can save My::Transaction\n\n      Others, can all: false, cannot all: false\n      --------------------------------------------------------------------------------\n        1. Others can view My::Transaction\n\n\n\n===== My::SecuredTransaction =====\n\n      Supreme_user, can all: true, cannot all: false\n      --------------------------------------------------------------------------------\n        1. Supreme_user can do anything except if explicitly stated otherwise\n\n      Admin, can all: true, cannot all: false\n      --------------------------------------------------------------------------------\n        1. Admin can do anything except if explicitly stated otherwise\n        2. Admin cannot delete My::Transaction\n\n      Finance, can all: false, cannot all: false\n      --------------------------------------------------------------------------------\n        1. Finance can view My::Transaction\n\n\n\n\n\nPrinted at 26-09-2015 12:19PM +07:00"
+    expected_output = "===== My::Transaction =====\n\n      General_user, can all: false, cannot all: false\n      --------------------------------------------------------------------------------\n        1. General_user can edit My::Transaction\n        2. General_user can save My::Transaction\n\n      Others, can all: false, cannot all: false\n      --------------------------------------------------------------------------------\n        1. Others can view My::Transaction\n\n\n\n===== My::SecuredTransaction =====\n\n      Supreme_user, can all: true, cannot all: false\n      --------------------------------------------------------------------------------\n        1. Supreme_user can do anything except if explicitly stated otherwise\n\n      Admin, can all: true, cannot all: false\n      --------------------------------------------------------------------------------\n        1. Admin can do anything except if explicitly stated otherwise\n        2. Admin cannot delete My::SecuredTransaction\n\n      Finance, can all: false, cannot all: false\n      --------------------------------------------------------------------------------\n        1. Finance can view My::SecuredTransaction\n\n      Others, can all: false, cannot all: false\n      --------------------------------------------------------------------------------\n        1. Others can view My::SecuredTransaction, with condition\n\n\n\n\n\n"
     bali_output = Bali::Printer.pretty_print
 
     # remove date


### PR DESCRIPTION
`clear_rules` would not clear rules within `others` block if not necessary
