### PR TITLE
better error message when role is nil and objection is can! or cannot!

### DIFF
--- a/lib/bali/foundations/exceptions/authorization_error.rb
+++ b/lib/bali/foundations/exceptions/authorization_error.rb
@@ -12,6 +12,8 @@ class Bali::AuthorizationError < Bali::Error
   attr_accessor :target
 
   def to_s
+    # better error message for nil, so that it won't be empty
+    role = self.role ? self.role : "<nil>"
     "Role #{role} is performing #{operation} using precedence #{auth_level}"
   end
 end

--- a/lib/bali/objector.rb
+++ b/lib/bali/objector.rb
@@ -98,12 +98,13 @@ module Bali::Objector::Statics
             break
           elsif deducted_roles.is_a?(Array)
             break
-          else
-            # keep it nil if _subtarget_roles is not either String, Symbol or Array
-            deducted_roles = nil
           end
         end # if matching class
       end # each TRANSLATED_SUBTARGET_ROLES
+
+      if deducted_roles.nil?
+        raise Bali::AuthorizationError, "Bali does not know how to process roles: #{_subtarget_roles}"
+      end
 
       return deducted_roles
     end # if

--- a/spec/objections_spec.rb
+++ b/spec/objections_spec.rb
@@ -670,6 +670,9 @@ describe "Model objections" do
         it "can't edit or update transaction" do
           txn.can?(nil, :edit).should be_falsey
           txn.can?(nil, :update).should be_falsey
+          expect do
+            txn.can!(nil, :update)
+          end.to raise_error(Bali::Error, "Role <nil> is performing update using precedence can")
         end
       end
 


### PR DESCRIPTION
`nil` will be printed <nil> when objecting with can! or cannot! for better readability
