### PR TITLE
Declare multi operations with decider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,4 +71,4 @@
 == Version 2.1.2
 
 1. `nil` will be printed <nil> when objecting with can! or cannot! for better readability.
-2. Bug fixes on declaring multiple rules with decider, only the first rule is defined, the others are ignored.
+2. Bug fixes on declaring multiple rules with decider. Previously, others were ignored--now, every single rule will get defined whether decider is present or not.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,3 +67,8 @@
 
 1. Bug fixes on `clear_rules` which it clear rules defined in `others` even when not asked to
 2. Bug fixes on `Bali::Printer` where inherited rules print the wrong target class due to another bug in an internal file (but doesn't hamper rules-checking logic)
+
+== Version 2.1.2
+
+1. `nil` will be printed <nil> when objecting with can! or cannot! for better readability.
+2. Bug fixes on declaring multiple rules with decider, only the first rule is defined, the others are ignored.

--- a/lib/bali/dsl/rules_for_dsl.rb
+++ b/lib/bali/dsl/rules_for_dsl.rb
@@ -101,33 +101,32 @@ class Bali::RulesForDsl
   end # others
 
   # to define can and cant is basically using this method
-  def bali_process_auth_rules(auth_val, operations)
+  def bali_process_auth_rules(auth_val, args)
     conditional_hash = nil
+    operations = []
 
-    # scan operations for options
-    operations.each do |elm|
+    # scan args for options
+    args.each do |elm|
       if elm.is_a?(Hash)
         conditional_hash = elm
+      else
+        operations << elm
       end
     end
 
-    if conditional_hash
-      op = operations[0]
+    # add operation one by one
+    operations.each do |op|
       rule = Bali::Rule.new(auth_val, op)
-      if conditional_hash[:if] || conditional_hash["if"]
-        rule.decider = conditional_hash[:if] || conditional_hash["if"]
-        rule.decider_type = :if
-      elsif conditional_hash[:unless] || conditional_hash[:unless]
-        rule.decider = conditional_hash[:unless] || conditional_hash["unless"]
-        rule.decider_type = :unless
+      if conditional_hash
+        if conditional_hash[:if] || conditional_hash["if"]
+          rule.decider = conditional_hash[:if] || conditional_hash["if"]
+          rule.decider_type = :if
+        elsif conditional_hash[:unless] || conditional_hash[:unless]
+          rule.decider = conditional_hash[:unless] || conditional_hash["unless"]
+          rule.decider_type = :unless
+        end
       end
       self.current_rule_group.add_rule(rule)
-    else
-      # no conditional hash, proceed adding operations one by one
-      operations.each do |op|
-        rule = Bali::Rule.new(auth_val, op)
-        self.current_rule_group.add_rule(rule)
-      end
     end
   end # bali_process_auth_rules
 

--- a/lib/bali/version.rb
+++ b/lib/bali/version.rb
@@ -1,3 +1,3 @@
 module Bali
-  VERSION = "2.1.1"
+  VERSION = "2.1.2"
 end

--- a/spec/objections_spec.rb
+++ b/spec/objections_spec.rb
@@ -575,7 +575,7 @@ describe "Model objections" do
           describe "general user", can: [:view, :edit, :update], cannot: [:delete]
           describe "finance user" do
             can :update, :delete, :edit
-            can :delete, if: proc { |record| record.is_settled? }
+            can :delete, :undelete, if: proc { |record| record.is_settled? }
           end # finance_user description
           describe :monitoring do
             cannot_all
@@ -659,6 +659,15 @@ describe "Model objections" do
 
           txn.cannot?([:monitoring, :finance_user], :monitor).should be_falsey
           txn.cannot?([:finance_user, :monitoring], :monitor).should be_falsey
+        end
+
+        # this also test that rules with decider described simultaneously 
+        # is also working as expected
+        it "allows undeleting with role of finance" do
+          txn.is_settled = false
+          expect(txn.can?(:finance_user, :undelete)).to be_falsey
+          txn.is_settled = true
+          expect(txn.can?(:finance_user, :undelete)).to be_truthy
         end
       end
 


### PR DESCRIPTION
Bug fixes on declaring multiple rules with decider. Previously, others were ignored--now, every single rule will get defined whether decider is present or not.
