### PR TITLE
Refactoring rules definer

### DIFF
--- a/lib/bali/dsl/map_rules_dsl.rb
+++ b/lib/bali/dsl/map_rules_dsl.rb
@@ -47,7 +47,7 @@ class Bali::MapRulesDsl
   end
 
   def can(*params)
-    raise Bali::DslError, "can block must be within describe block"
+    raise Bali::DslError, "can block must be within role block"
   end
 
   def cant(*params)
@@ -56,15 +56,15 @@ class Bali::MapRulesDsl
   end
 
   def cannot(*params)
-    raise Bali::DslError, "cant block must be within describe block"
+    raise Bali::DslError, "cant block must be within role block"
   end
 
   def can_all(*params)
-    raise Bali::DslError, "can_all block must be within describe block"
+    raise Bali::DslError, "can_all block must be within role block"
   end
 
   def clear_rules
-    raise Bali::DslError, "clear_rules must be called within describe block"
+    raise Bali::DslError, "clear_rules must be called within role block"
   end
 
   def cant_all(*params)
@@ -73,6 +73,6 @@ class Bali::MapRulesDsl
   end
 
   def cannot_all(*params)
-    raise Bali::DslError, "cant_all block must be within describe block"
+    raise Bali::DslError, "cant_all block must be within role block"
   end
 end

--- a/lib/bali/dsl/map_rules_dsl.rb
+++ b/lib/bali/dsl/map_rules_dsl.rb
@@ -42,6 +42,10 @@ class Bali::MapRulesDsl
     raise Bali::DslError, "describe block must be within rules_for block"
   end
 
+  def role(*params)
+    raise Bali::DslError, "role block must be within rules_for block"
+  end
+
   def can(*params)
     raise Bali::DslError, "can block must be within describe block"
   end

--- a/lib/bali/dsl/rules_for_dsl.rb
+++ b/lib/bali/dsl/rules_for_dsl.rb
@@ -4,6 +4,11 @@ class Bali::RulesForDsl
   attr_accessor :map_rules_dsl
   attr_accessor :current_rule_group
 
+  # all to be processed subtargets
+  attr_accessor :current_subtargets
+  # rules defined with hash can: [] and cannot: []
+  attr_accessor :shortcut_rules
+
   def initialize(map_rules_dsl)
     @@lock = Mutex.new
     self.map_rules_dsl = map_rules_dsl
@@ -12,123 +17,42 @@ class Bali::RulesForDsl
   def current_rule_class
     self.map_rules_dsl.current_rule_class
   end
+  protected :current_rule_class
 
-  def describe(*params)
+  def role(*params)
     @@lock.synchronize do
-      subtargets = []
-      rules = {}
-
-      params.each do |passed_argument|
-        if passed_argument.is_a?(Symbol) || passed_argument.is_a?(String)
-          subtargets << passed_argument
-        elsif passed_argument.is_a?(NilClass)
-          subtargets << passed_argument
-        elsif passed_argument.is_a?(Array)
-          subtargets += passed_argument
-        elsif passed_argument.is_a?(Hash)
-          rules = passed_argument
+      bali_scrap_actors(*params)
+      bali_scrap_shortcut_rules(*params)
+      current_subtargets.each do |subtarget|
+        if block_given?
+          bali_process_subtarget(subtarget) do
+            yield
+          end
         else
-          raise Bali::DslError, "Allowed argument for describe: symbol, string, nil and hash"
+          bali_process_subtarget(subtarget)
         end
       end
+    end
+  end # role
 
-      target_class = self.map_rules_dsl.current_rule_class.target_class
-
-      subtargets.each do |subtarget|
-        rule_group = self.current_rule_class.rules_for(subtarget)
-        if rule_group.nil?
-          rule_group = Bali::RuleGroup.new(target_class, subtarget)
-        end
-
-        self.current_rule_group = rule_group
-
-        if block_given?
-          yield
-        else
-          # auth_val is either can or cant
-          rules.each do |auth_val, operations|
-            if operations.is_a?(Array)
-              operations.each do |op|
-                rule = Bali::Rule.new(auth_val, op)
-                self.current_rule_group.add_rule(rule)
-              end
-            else
-              operation = operations # well, basically is 1 only
-              rule = Bali::Rule.new(auth_val, operation)
-              self.current_rule_group.add_rule(rule)
-            end
-          end # each rules
-        end # block_given?
-
-        # add current_rule_group
-        self.map_rules_dsl.current_rule_class.add_rule_group(self.current_rule_group)
-      end # each subtarget
-    end # sync block
-  end # describe
+  def describe(*params)
+    if block_given?
+      role(*params) do
+        yield
+      end
+    else
+      role(*params)
+    end
+  end
 
   # others block
   def others(*params)
-    @@lock.synchronize do
-      rules = {}
-
-      params.each do |passed_argument|
-        if passed_argument.is_a?(Hash)
-          rules = passed_argument
-        else
-          raise Bali::DslError, "Allowed argument for others: hash"
-        end
-      end
-
-      self.current_rule_group  = self.map_rules_dsl.current_rule_class.others_rule_group
-
-      if block_given?
+    if block_given?
+      role("__*__") do
         yield
-      else
-        rules.each do |auth_val, operations|
-          if operations.is_a?(Array)
-            operations.each do |op|
-              rule = Bali::Rule.new(auth_val, op)
-              self.current_rule_group.add_rule(rule)
-            end
-          else
-            operation = operations
-            rule = Bali::Rule.new(auth_val, operation)
-            self.current_rule_group.add_rule(rule)
-          end
-        end # each rules
-      end # block_given?
-    end # synchronize
+      end
+    end
   end # others
-
-  # to define can and cant is basically using this method
-  def bali_process_auth_rules(auth_val, args)
-    conditional_hash = nil
-    operations = []
-
-    # scan args for options
-    args.each do |elm|
-      if elm.is_a?(Hash)
-        conditional_hash = elm
-      else
-        operations << elm
-      end
-    end
-
-    # add operation one by one
-    operations.each do |op|
-      rule = Bali::Rule.new(auth_val, op)
-      if conditional_hash
-        if conditional_hash[:if] || conditional_hash["if"]
-          rule.decider = conditional_hash[:if] || conditional_hash["if"]
-          rule.decider_type = :if
-        elsif conditional_hash[:unless] || conditional_hash[:unless]
-          rule.decider = conditional_hash[:unless] || conditional_hash["unless"]
-          rule.decider_type = :unless
-        end
-      end
-      self.current_rule_group.add_rule(rule)
-    end
-  end # bali_process_auth_rules
 
   # clear all defined rules
   def clear_rules
@@ -163,4 +87,95 @@ class Bali::RulesForDsl
     puts "Deprecation Warning: declaring rules with cant_all will be deprecated on major release 3.0, use cannot_all instead"
     cannot_all
   end
+  
+  private
+    def bali_scrap_actors(*params)
+      self.current_subtargets = []
+      params.each do |passed_argument|
+        if passed_argument.is_a?(Symbol) || passed_argument.is_a?(String)
+          self.current_subtargets << passed_argument
+        elsif passed_argument.is_a?(NilClass)
+          self.current_subtargets << passed_argument
+        elsif passed_argument.is_a?(Array)
+          self.current_subtargets += passed_argument
+        end
+      end
+      nil
+    end
+
+    def bali_scrap_shortcut_rules(*params)
+      self.shortcut_rules = {}
+      params.each do |passed_argument|
+        if passed_argument.is_a?(Hash)
+          self.shortcut_rules = passed_argument
+        end
+      end
+      nil
+    end
+
+    def bali_process_subtarget(subtarget)
+      target_class = self.map_rules_dsl.current_rule_class.target_class
+      rule_class = self.map_rules_dsl.current_rule_class
+
+      rule_group = rule_class.rules_for(subtarget)
+
+      if rule_group.nil?
+        rule_group = Bali::RuleGroup.new(target_class, subtarget)
+      end
+
+      self.current_rule_group = rule_group
+
+      if block_given?
+        yield
+      else
+        # auth_val is either can or cannot
+        shortcut_rules.each do |auth_val, operations|
+          if operations.is_a?(Array)
+            operations.each do |op|
+              rule = Bali::Rule.new(auth_val, op)
+              rule_group.add_rule(rule)
+            end
+          else
+            operation = operations # well, basically is 1 only
+            rule = Bali::Rule.new(auth_val, operation)
+            rule_group.add_rule(rule)
+          end
+        end # each rules
+      end # block_given?
+
+      # add current_rule_group
+      rule_class.add_rule_group(rule_group)
+
+      nil
+    end
+
+    # to define can and cant is basically using this method
+    def bali_process_auth_rules(auth_val, args)
+      conditional_hash = nil
+      operations = []
+
+      # scan args for options
+      args.each do |elm|
+        if elm.is_a?(Hash)
+          conditional_hash = elm
+        else
+          operations << elm
+        end
+      end
+
+      # add operation one by one
+      operations.each do |op|
+        rule = Bali::Rule.new(auth_val, op)
+        if conditional_hash
+          if conditional_hash[:if] || conditional_hash["if"]
+            rule.decider = conditional_hash[:if] || conditional_hash["if"]
+            rule.decider_type = :if
+          elsif conditional_hash[:unless] || conditional_hash[:unless]
+            rule.decider = conditional_hash[:unless] || conditional_hash["unless"]
+            rule.decider_type = :unless
+          end
+        end
+        self.current_rule_group.add_rule(rule)
+      end
+    end # bali_process_auth_rules
 end # class

--- a/lib/bali/dsl/rules_for_dsl.rb
+++ b/lib/bali/dsl/rules_for_dsl.rb
@@ -36,6 +36,7 @@ class Bali::RulesForDsl
   end # role
 
   def describe(*params)
+    puts "Bali Deprecation Warning: describing rules using describe will be deprecated on major release 3.0, use role instead"
     if block_given?
       role(*params) do
         yield

--- a/lib/bali/foundations/rule/rule_class.rb
+++ b/lib/bali/foundations/rule/rule_class.rb
@@ -27,9 +27,10 @@ class Bali::RuleClass
     if rule_group.is_a?(Bali::RuleGroup)
       target_user = rule_group.subtarget
       if target_user == "__*__" || target_user == :"__*__"
-        raise Bali::DslError, "__*__ is a reserved subtarget used by Bali's internal"
+        self.others_rule_group = rule_group
+      else
+        self.rule_groups[rule_group.subtarget] = rule_group
       end
-      self.rule_groups[rule_group.subtarget] = rule_group
     else
       raise Bali::DslError, "Rule group must be an instance of Bali::RuleGroup, got: #{rule_group.class.name}"
     end

--- a/lib/bali/objector.rb
+++ b/lib/bali/objector.rb
@@ -43,8 +43,8 @@ end
 module Bali::Objector::Statics
   # FUZY-ed value is happen when it is not really clear, need further cross checking,
   # whether it is really allowed or not. It happens for example in block with others, such as this:
-  # 
-  # describe :finance do
+  #
+  # role :finance do
   #   cannot :view
   # end
   # others do
@@ -55,7 +55,7 @@ module Bali::Objector::Statics
   # In the example above, objecting cannot view on finance will result in STRONG_FALSE, but
   # objecting can index on finance will result in FUZY_TRUE.
   #
-  # Eventually, all FUZY value will be normal TRUE or FALSE if no definite counterpart 
+  # Eventually, all FUZY value will be normal TRUE or FALSE if no definite counterpart
   # is found/defined
   BALI_FUZY_FALSE = -2
   BALI_FUZY_TRUE = 2
@@ -69,7 +69,7 @@ module Bali::Objector::Statics
       return false
     elsif bali_bool_value > 0
       return true
-    else 
+    else
       raise Bali::Error, "Bali bool value can either be negative or positive integer"
     end
   end
@@ -126,9 +126,9 @@ module Bali::Objector::Statics
     end
 
     rule_group = Bali::Integrators::Rule.rule_group_for(klass, subtarget)
-    other_rule_group = Bali::Integrators::Rule.rule_group_for(klass, "__*__") 
+    other_rule_group = Bali::Integrators::Rule.rule_group_for(klass, "__*__")
 
-    rule = nil 
+    rule = nil
 
     # default of can? is false whenever RuleClass for that class is undefined
     # or RuleGroup for that subtarget is not defined
@@ -136,7 +136,7 @@ module Bali::Objector::Statics
       # no more chance for checking
       return BALI_FALSE if other_rule_group.nil?
     else
-      # get the specific rule from its own describe block
+      # get the specific rule from its own role block
       rule = rule_group.get_rule(:can, operation)
     end
 
@@ -155,7 +155,7 @@ module Bali::Objector::Statics
         check_val = self.bali_cannot?(subtarget, operation, record, _options)
 
         # check further whether cant is defined to overwrite this can_all
-        if check_val == BALI_TRUE 
+        if check_val == BALI_TRUE
           return BALI_FALSE
         else
           return BALI_TRUE
@@ -171,7 +171,7 @@ module Bali::Objector::Statics
       # default if can? for undefined rule is false, after related clause
       # cannot be found in cannot?
 
-      unless options[:cross_check] 
+      unless options[:cross_check]
         options[:cross_check] = true
         cross_check_value = self.bali_cannot?(subtarget, operation, record, options)
       end
@@ -184,10 +184,10 @@ module Bali::Objector::Statics
       # 1. Definite answer such as BALI_TRUE and BALI_FALSE is to be prioritised over
       #    FUZY answer, because definite answer is not gathered from others block where
       #    FUZY answer is. Therefore, it is an intended result
-      # 2. If the answer is FUZY, otherly_rule only be considered if the result 
+      # 2. If the answer is FUZY, otherly_rule only be considered if the result
       #    is either FUZY TRUE or FUZY FALSE, or
       # 3. Or, when already in cross check mode, we cannot retrieve cross_check_value
-      #    what we can is instead, if otherly rule is available, just to try the odd 
+      #    what we can is instead, if otherly rule is available, just to try the odd
       if (otherly_rule && cross_check_value && !(cross_check_value == BALI_TRUE || cross_check_value == BALI_FALSE)) ||
           (otherly_rule && (cross_check_value == BALI_FUZY_FALSE || cross_check_value == BALI_FUZY_TRUE)) ||
           (otherly_rule && options[:cross_check] && cross_check_value.nil?)
@@ -271,7 +271,7 @@ module Bali::Objector::Statics
     if rule_group.nil?
       return BALI_TRUE if other_rule_group.nil?
     else
-      # get the specific rule from its own describe block
+      # get the specific rule from its own role block
       rule = rule_group.get_rule(:cannot, operation)
     end
 
@@ -282,7 +282,7 @@ module Bali::Objector::Statics
         _options = options.dup
         _options[:cross_check] = true
         _options[:original_subtarget] = original_subtarget if _options[:original_subtarget].nil?
-        
+
         # check further whether defined in can?
         check_val = self.bali_can?(subtarget, operation, record, _options)
 
@@ -377,7 +377,7 @@ module Bali::Objector::Statics
     # well, it is largely not used unless decider's is 2 arity
     options[:original_subtarget] = options[:original_subtarget].nil? ? subtarget_roles : options[:original_subtarget]
 
-    can_value = BALI_FALSE 
+    can_value = BALI_FALSE
     role = nil
 
     subs.each do |subtarget|
@@ -415,7 +415,7 @@ module Bali::Objector::Statics
       if cant_value == BALI_FALSE
         role = subtarget
         if block_given?
-          yield options[:original_subtarget], role, bali_translate_response(cant_value) 
+          yield options[:original_subtarget], role, bali_translate_response(cant_value)
         end
       end
     end

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -104,16 +104,6 @@ describe Bali do
             end
           end
         end.to_not raise_error
-
-        expect do
-          Bali.map_rules do
-            rules_for My::Transaction do
-              describe :general_user, nil, -> { "finance_user "} do
-                can :print
-              end
-            end
-          end
-        end.to raise_error(Bali::DslError)
       end
 
       context "when inheriting" do

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -44,7 +44,7 @@ describe Bali do
 
         Bali.map_rules do
           rules_for My::Transaction do
-            describe :general_user do |record|
+            role :general_user do |record|
               can :update, :delete
               can :delete, if: -> { record.is_settled? }
             end
@@ -60,7 +60,7 @@ describe Bali do
         expect do
           Bali.map_rules do
             rules_for My::Transaction do
-              describe :general_user do
+              role :general_user do
                 can :print
               end
             end
@@ -70,7 +70,7 @@ describe Bali do
         expect do
           Bali.map_rules do
             rules_for My::Transaction do
-              describe "finance user" do
+              role "finance user" do
                 can :print
               end
             end
@@ -80,7 +80,7 @@ describe Bali do
         expect do
           Bali.map_rules do
             rules_for My::Transaction do
-              describe [:general_user, "finance user"] do
+              role [:general_user, "finance user"] do
                 can :print
               end
             end
@@ -90,7 +90,7 @@ describe Bali do
         expect do
           Bali.map_rules do
             rules_for My::Transaction do
-              describe :general_user, can: [:print]
+              role :general_user, can: [:print]
             end
           end
         end.to_not raise_error
@@ -98,7 +98,7 @@ describe Bali do
         expect do
           Bali.map_rules do
             rules_for My::Transaction do
-              describe :general_user, :finance_user, [:guess, nil], can: [:show] do
+              role :general_user, :finance_user, [:guess, nil], can: [:show] do
                 can :print
               end
             end
@@ -111,7 +111,7 @@ describe Bali do
           expect do
             Bali.map_rules do
               rules_for My::Transaction, inherits: My::SecuredTransaction do
-              end 
+              end
             end
           end.to raise_error(Bali::DslError)
         end
@@ -129,12 +129,12 @@ describe Bali do
       end
     end
 
-    context "when describing each rules using describe" do
+    context "when describing each rules using role" do
       it "can define nil rule group" do
         expect(Bali::Integrators::Rule.rule_classes.size).to eq(0)
         Bali.map_rules do
           rules_for My::Transaction do
-            describe nil do
+            role nil do
               can :view
             end
           end
@@ -143,17 +143,17 @@ describe Bali do
         Bali::Integrators::Rule.rule_class_for(My::Transaction).class.should == Bali::RuleClass
       end
 
-      it "disallows calling describe outside of rules_for" do
+      it "disallows calling role outside of rules_for" do
         expect do
           Bali.map_rules do
-            describe :general_user, can: :show
+            role :general_user, can: :show
           end.to raise_error(Bali::DslError)
         end
 
         expect do
           Bali.map_rules do
             rules_for My::Transaction do
-              describe :general_user do
+              role :general_user do
                 can :show
               end
             end
@@ -161,7 +161,7 @@ describe Bali do
         end.to_not raise_error
       end
 
-      it "disallows calling can outside of describe block" do
+      it "disallows calling can outside of role block" do
         expect do
           Bali.map_rules do
             can :show
@@ -171,7 +171,7 @@ describe Bali do
         expect do
           Bali.map_rules do
             rules_for My::Transaction do
-              describe :general_user do
+              role :general_user do
                 can :show
               end
             end
@@ -179,7 +179,7 @@ describe Bali do
         end.to_not raise_error
       end
 
-      it "disallows calling cannot outside of describe block" do
+      it "disallows calling cannot outside of role block" do
         expect do
           Bali.map_rules do
             cannot :show
@@ -189,7 +189,7 @@ describe Bali do
         expect do
           Bali.map_rules do
             rules_for My::Transaction do
-              describe :general_user do
+              role :general_user do
                 cannot :show
               end
             end
@@ -197,7 +197,7 @@ describe Bali do
         end.to_not raise_error
       end
 
-      it "disallows calling can_all outside of describe block" do
+      it "disallows calling can_all outside of role block" do
         expect do
           Bali.map_rules do
             can_all
@@ -207,7 +207,7 @@ describe Bali do
         expect do
           Bali.map_rules do
             rules_for My::Transaction do
-              describe :general_user do
+              role :general_user do
                 can_all
               end
             end
@@ -215,7 +215,7 @@ describe Bali do
         end.to_not raise_error
       end
 
-      it "disallows calling cannot_all outside of describe block" do
+      it "disallows calling cannot_all outside of role block" do
         expect do
           Bali.map_rules do
             cannot_all
@@ -225,14 +225,14 @@ describe Bali do
         expect do
           Bali.map_rules do
             rules_for My::Transaction do
-              describe :general_user do
+              role :general_user do
                 cannot_all
               end
             end
           end
         end.to_not raise_error
       end
-    end # context describe
+    end # context role
 
     context "others" do
       it "disallow calling others outside of rules_for" do
@@ -289,7 +289,7 @@ describe Bali do
         end.to_not raise_error
       end
 
-      it "disallows calling can_all outside of describe block" do
+      it "disallows calling can_all outside of role block" do
         expect do
           Bali.map_rules do
             can_all
@@ -307,7 +307,7 @@ describe Bali do
         end.to_not raise_error
       end
 
-      it "disallows calling cannot_all outside of describe block" do
+      it "disallows calling cannot_all outside of role block" do
         expect do
           Bali.map_rules do
             cannot_all
@@ -330,8 +330,8 @@ describe Bali do
       expect(Bali::Integrators::Rule.rule_classes.size).to eq(0)
       Bali.map_rules do
         rules_for My::Transaction do
-          describe :general_user, can: :show
-          describe :finance_user do
+          role :general_user, can: :show
+          role :finance_user do
             can :update, :delete, :edit
             can :delete, if: proc { |record| record.is_settled? }
           end
@@ -345,11 +345,11 @@ describe Bali do
       expect(Bali::Integrators::Rule.rule_classes.size).to eq(0)
       Bali.map_rules do
         rules_for My::Transaction do
-          describe(:general_user, :finance_user, can: [:show])
-          describe :general_user, :finance_user do
+          role(:general_user, :finance_user, can: [:show])
+          role :general_user, :finance_user do
             can :print
           end
-          describe :finance_user do
+          role :finance_user do
             can :delete, if: proc { |record| record.is_settled? }
           end
         end
@@ -369,10 +369,10 @@ describe Bali do
       rule_group_gu.get_rule(:can, :delete).class.should == NilClass
     end
 
-    it "does not allowe describe without rules_for" do
+    it "does not allow role without rules_for" do
       expect do
         Bali.map_rules do
-          describe :general_user, can: [:print]
+          role :general_user, can: [:print]
         end
       end.to raise_error(Bali::DslError)
     end
@@ -383,7 +383,7 @@ describe Bali do
       expect(Bali::Integrators::Rule.rule_classes.size).to eq(0)
       Bali.map_rules do
         rules_for My::Transaction do
-          describe :finance_user do
+          role :finance_user do
             can :delete, if: proc { |record| record.is_settled? }
             cannot :payout, if: proc { |record| !record.is_settled? }
           end
@@ -407,7 +407,7 @@ describe Bali do
       Bali.clear_rules
       Bali.map_rules do
         rules_for My::Transaction do
-          describe :finance_user do
+          role :finance_user do
             cannot :delete, unless: proc { |record| record.is_settled? }
             can :payout, unless: proc { |record| !record.is_settled? }
           end
@@ -428,7 +428,7 @@ describe Bali do
       expect(Bali::Integrators::Rule.rule_classes.size).to eq(0)
       Bali.map_rules do
         rules_for My::Transaction do
-          describe :finance_user do
+          role :finance_user do
             cannot :chargeback, unless: proc { |record| record.is_settled? }
           end
         end
@@ -447,7 +447,7 @@ describe Bali do
       Bali.clear_rules
       Bali.map_rules do
         rules_for My::Transaction do
-          describe :finance_user do
+          role :finance_user do
             can :chargeback, if: proc { |record| record.is_settled? }
           end
         end
@@ -466,7 +466,7 @@ describe Bali do
     it "should allow rule group to be defined" do
       Bali.map_rules do
         rules_for My::Transaction do
-          describe :general_user, can: :show
+          role :general_user, can: :show
         end
       end
       Bali::Integrators::Rule.rule_classes.size.should == 1
@@ -478,7 +478,7 @@ describe Bali do
 
       Bali.map_rules do
         rules_for My::Transaction do
-          describe :general_user, can: :show
+          role :general_user, can: :show
         end
       end
       Bali::Integrators::Rule.rule_classes.size.should == 1
@@ -493,7 +493,7 @@ describe Bali do
       expect(Bali::Integrators::Rule.rule_classes.size).to eq(0)
       Bali.map_rules do
         rules_for My::Transaction do
-          describe :general_user, can: [:update, :delete, :edit]
+          role :general_user, can: [:update, :delete, :edit]
         end
       end
       expect(Bali::Integrators::Rule.rule_classes.size).to eq(1)
@@ -503,8 +503,8 @@ describe Bali do
 
       Bali.map_rules do
         rules_for My::Transaction do
-          describe :general_user, can: :show
-          describe :finance_user, can: [:update, :delete, :edit]
+          role :general_user, can: :show
+          role :finance_user, can: [:update, :delete, :edit]
         end
       end
       expect(Bali::Integrators::Rule.rule_classes.size).to eq(1)
@@ -519,7 +519,7 @@ describe Bali do
         expect do
           Bali.map_rules do
             rules_for My::Transaction do
-              describe :admin_user do
+              role :admin_user do
                 can_all
               end
               others do
@@ -538,7 +538,7 @@ describe Bali do
         expect do
           Bali.map_rules do
             rules_for My::Transaction do
-              describe :admin_user do
+              role :admin_user do
                 can_all
               end
               others can: [:view]

--- a/spec/foundations_spec.rb
+++ b/spec/foundations_spec.rb
@@ -6,14 +6,6 @@ describe "Bali foundations" do
       rule_class = Bali::RuleClass.new(My::Transaction)
     end
 
-    it "does not allow defining rule group for __*__" do
-      expect do
-        rule_group = Bali::RuleGroup.new(My::Transaction, "__*__")
-        rule_class = Bali::RuleClass.new(My::Transaction)
-        rule_class.add_rule_group(rule_group)
-      end.to raise_error Bali::DslError
-    end
-
     it "does not allow creation of instance for target other than class" do
       expect { Bali::RuleClass.new(Object.new) }.to raise_error(Bali::DslError)
     end

--- a/spec/foundations_spec.rb
+++ b/spec/foundations_spec.rb
@@ -72,7 +72,7 @@ describe "Bali foundations" do
         expect(cloned_rc.others_rule_group.object_id).to_not eq(rule_class.others_rule_group.object_id)
 
         rule_class.rule_groups.each do |subtarget, rule_group|
-          cloned_rg = cloned_rc.rule_groups[subtarget] 
+          cloned_rg = cloned_rc.rule_groups[subtarget]
           expect(cloned_rg.object_id).to_not eq(rule_group.object_id)
 
           expect(cloned_rg.cants.object_id).to_not eq(rule_group.cants.object_id)
@@ -88,10 +88,10 @@ describe "Bali foundations" do
         Bali.clear_rules
         Bali.map_rules do
           rules_for My::Transaction do
-            describe :general_user, :finance do
+            role :general_user, :finance do
               can :print
             end
-            describe :finance do
+            role :finance do
               can :edit, :update, :view, :save
             end
             others do
@@ -125,14 +125,14 @@ describe "Bali foundations" do
         expect(stxn_finance_rg.cans.length).to eq(5)
         expect(stxn_finance_rg.cans.keys).to include(:print, :edit, :update, :view, :save)
         expect(stxn_finance_rg.cants.length).to eq(0)
-      end 
+      end
 
       it "clears only rules from finance" do
         txn_finance_rg = Bali::Integrators::Rule.rule_group_for(My::Transaction, "finance")
 
         Bali.map_rules do
           rules_for My::SecuredTransaction, inherits: My::Transaction do
-            describe :finance do
+            role :finance do
               clear_rules
               can :view, :print
             end

--- a/spec/objections_spec.rb
+++ b/spec/objections_spec.rb
@@ -52,16 +52,16 @@ describe "Model objections" do
       Bali.map_rules do
         roles_for My::Employee, :roles
         rules_for My::Transaction do
-          describe :admin, :general_user do
+          role :admin, :general_user do
             can :show, :edit, :new
           end
-          describe :general_user do
+          role :general_user do
             can :copy
           end
-          describe :admin do
+          role :admin do
             can :delete
           end
-          describe nil, can: [:show]
+          role nil, can: [:show]
         end
       end
     end
@@ -125,14 +125,14 @@ describe "Model objections" do
       Bali.map_rules do
         roles_for My::Employee, :roles
         rules_for My::Transaction do
-          describe :admin, :general_user do
+          role :admin, :general_user do
             can :show
           end
-          describe :general_user do
+          role :general_user do
             can :edit, if: proc { |record, user| user.exp_years > 3 }
             can :cancel, if: proc { |record, user| !record.is_settled? && user.exp_years > 3 }
           end
-          describe(:admin) { can_all }
+          role(:admin) { can_all }
         end
       end
 
@@ -211,7 +211,7 @@ describe "Model objections" do
       Bali.map_rules do
         roles_for My::Employee, :roles
         rules_for My::Transaction do
-          describe :general_user do
+          role :general_user do
             can :show
             can :edit, unless: proc { |record, user|
               (user.exp_years <= 3)
@@ -220,7 +220,7 @@ describe "Model objections" do
               record.is_settled? && (user.exp_years > 3)
             }
           end
-          describe(:admin) { can_all }
+          role(:admin) { can_all }
         end
       end
 
@@ -271,12 +271,12 @@ describe "Model objections" do
       Bali.clear_rules
       Bali.map_rules do
         rules_for My::Transaction do
-          describe(:supreme_user) { can_all }
-          describe :admin do
+          role(:supreme_user) { can_all }
+          role :admin do
             can_all
             cannot :delete
           end
-          describe :finance do
+          role :finance do
             cannot :view
             can :print
           end
@@ -288,7 +288,7 @@ describe "Model objections" do
         end # rules_for
 
         rules_for My::SecuredTransaction, inherits: My::Transaction do
-          describe :finance do
+          role :finance do
             cannot_all
           end
         end
@@ -302,7 +302,7 @@ describe "Model objections" do
         expect(txn.can?(:supreme_user, :delete)).to be_truthy
         expect(txn.cannot?(:supreme_user, :delete)).to be_falsey
       end
-      
+
       it "should allow to print transaction" do
         expect(txn.can?(:supreme_user, :print)).to be_truthy
         expect(txn.cannot?(:supreme_user, :print)).to be_falsey
@@ -382,12 +382,12 @@ describe "Model objections" do
       Bali.clear_rules
       Bali.map_rules do
         rules_for My::Transaction do
-          describe(:supreme_user) { can_all }
-          describe :admin do
+          role(:supreme_user) { can_all }
+          role :admin do
             can_all
             cannot :delete
           end
-          describe :finance do
+          role :finance do
             cannot :view
             can :print
           end
@@ -407,7 +407,7 @@ describe "Model objections" do
         expect(txn.can?(:supreme_user, :delete)).to be_truthy
         expect(txn.cannot?(:supreme_user, :delete)).to be_falsey
       end
-      
+
       it "should allow to print transaction" do
         expect(txn.can?(:supreme_user, :print)).to be_truthy
         expect(txn.cannot?(:supreme_user, :print)).to be_falsey
@@ -480,12 +480,12 @@ describe "Model objections" do
       Bali.clear_rules
       Bali.map_rules do
         rules_for My::Transaction do
-          describe(:supreme_user) { can_all }
-          describe(:admin_user) do
+          role(:supreme_user) { can_all }
+          role :admin_user do
             can_all
             cannot :delete
           end
-          describe(:general_user) do
+          role :general_user do
             cannot_all
             can :view
             can :print, if: proc { |txn| txn.is_settled? }
@@ -562,26 +562,26 @@ describe "Model objections" do
     before(:each) do
       Bali.map_rules do
         rules_for My::Transaction do
-          describe(:supreme_user) { can_all }
-          describe :admin_user do
+          role(:supreme_user) { can_all }
+          role :admin_user do
             can_all
             can :cancel,
               if: proc { |record| record.payment_channel == "CREDIT_CARD" &&
                                   !record.is_settled? }
           end
-          describe :general_user, :finance_user, :monitoring do
+          role :general_user, :finance_user, :monitoring do
             can :ask
           end
-          describe "general user", can: [:view, :edit, :update], cannot: [:delete]
-          describe "finance user" do
+          role "general user", can: [:view, :edit, :update], cannot: [:delete]
+          role "finance user" do
             can :update, :delete, :edit
             can :delete, :undelete, if: proc { |record| record.is_settled? }
           end # finance_user description
-          describe :monitoring do
+          role :monitoring do
             cannot_all
             can :monitor
           end
-          describe nil do
+          role nil do
             can :view
           end
         end # rules_for
@@ -661,7 +661,7 @@ describe "Model objections" do
           txn.cannot?([:finance_user, :monitoring], :monitor).should be_falsey
         end
 
-        # this also test that rules with decider described simultaneously 
+        # this also test that rules with decider described simultaneously
         # is also working as expected
         it "allows undeleting with role of finance" do
           txn.is_settled = false
@@ -894,11 +894,11 @@ describe "Model objections" do
       end
     end
 
-    context "when clearing rules" do 
+    context "when clearing rules" do
       before do
         Bali.map_rules do
           rules_for My::SecuredTransaction, inherits: My::Transaction do
-            describe :general_user do
+            role :general_user do
               clear_rules
               can :view
             end
@@ -941,19 +941,19 @@ describe "Model objections" do
         Bali.map_rules do
           roles_for My::Employee, :roles
           rules_for My::SecuredTransaction, inherits: My::Transaction do
-            describe :admin_user do
+            role :admin_user do
               can :cancel, if: proc { |record, user|
                 record.payment_channel == "CREDIT_CARD" && !record.is_settled &&
                   user.exp_years >= 3
               }
             end
-            describe :general_user do
+            role :general_user do
               cannot :update, :edit
             end
-            describe :finance_user do
+            role :finance_user do
               cannot :delete
             end
-            describe(nil) { cannot_all }
+            role(nil) { cannot_all }
           end
         end # map_rules
       end # before
@@ -1046,7 +1046,7 @@ describe "Model objections" do
   it "should respect precedence" do
     Bali.map_rules do
       rules_for My::Transaction do
-        describe :user do
+        role :user do
           cannot_all
           can :show
 

--- a/spec/print_spec.rb
+++ b/spec/print_spec.rb
@@ -5,12 +5,12 @@ describe "Printing Bali Rules" do
   it "doesn't print others if unnecessary" do
     Bali.map_rules do
       rules_for My::Transaction do
-        describe(:supreme_user) { can_all }
-        describe(:admin) do
+        role(:supreme_user) { can_all }
+        role(:admin) do
           can_all
           cannot :delete
         end
-        describe :finance do
+        role :finance do
           can :view, :print
           can :edit, :save
         end
@@ -20,7 +20,7 @@ describe "Printing Bali Rules" do
       end
 
       rules_for My::SecuredTransaction, inherits: My::Transaction do
-        describe :finance do
+        role :finance do
           clear_rules
           can :view
         end
@@ -75,9 +75,9 @@ describe "Printing Bali Rules" do
 
 
 Printed at 26-09-2015 12:58PM +07:00}
-    
+
     expected_output_without_printed_at = output.gsub(/Printed.*/i, "")
-    bali_output = Bali::Printer.pretty_print 
+    bali_output = Bali::Printer.pretty_print
     bali_output_without_printed_at = bali_output.gsub(/Printed.*/, "")
 
     expect(expected_output_without_printed_at).to eq(bali_output_without_printed_at)
@@ -86,7 +86,7 @@ Printed at 26-09-2015 12:58PM +07:00}
   it "print others if necessary" do
     Bali.map_rules do
       rules_for My::Transaction do
-        describe :general_user do
+        role :general_user do
           can :edit, :save
         end
         others do
@@ -108,9 +108,9 @@ Printed at 26-09-2015 12:58PM +07:00}
   it "has 'printed at' date" do
     Bali.map_rules do
       rules_for My::Transaction do
-        describe(:general_user) do
+        role(:general_user) do
           can :edit
-        end # describe
+        end # role
       end # rules_for
     end # map_rules
 


### PR DESCRIPTION
The way rules defined are now re-factored, and as well, `describe` block is deprecated, replaced with `role` block.
