### PR TITLE
Fix bug when calling can? (and cant?) with only 2 arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,15 +91,18 @@
 5. Use class for defining rules
 6. Hook to ActiveModel without having to include `Bali::Authorizer`
 
-== Version 6.0.0rc2 (Apr 28, 2020)
+== Version 6.0.0rc2 (Apr 27, 2020)
 
 1. Hook into ActionView and ActionController
 2. Not storing the ruler class inside a `RULE_CLASS_MAP` to avoid caching it
 3. Not storing the role field mapper inside a `TRANSLATED_SUBTARGET_ROLES`
 
-== Version 6.0.0rc3 (Apr 29, 2020)
+== Version 6.0.0rc3 (May 01, 2020)
 
 1. Built-in `be_able_to` matcher for RSpec
 2. Renaming `Bali::Printer.pretty_print` to `Bali::Printer.printable`
 3. Uniform `can?` and `cant?` authorizization checker
 4. Adding `scope` block
+
+== Version 6.0.0rc4
+1. Bug fix for `can?` and `cant?` when passing 2 arguments.

--- a/lib/bali/statics/authorizer.rb
+++ b/lib/bali/statics/authorizer.rb
@@ -39,6 +39,10 @@ module Bali::Statics::Authorizer
       if arg2.nil? && arg3.nil? && obj.respond_to?(:current_user)
         arg2 = arg1
         arg1 = obj.current_user
+      elsif arg3.nil? && obj.respond_to?(:current_user)
+        arg3 = arg2
+        arg2 = arg1
+        arg1 = obj.current_user
       end
 
       arg3 = HelperFunctions.determine_model_class! obj, arg1, arg2, arg3

--- a/lib/bali/version.rb
+++ b/lib/bali/version.rb
@@ -1,3 +1,3 @@
 module Bali
-  VERSION = "6.0.0rc3"
+  VERSION = "6.0.0rc4"
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -12,6 +12,14 @@ describe UsersController do
       expect(response.body).to include("Cant see banner from helper? true")
       expect(response.body).to include("Can update transaction? true")
     end
+
+    context "as an accountant" do
+      let(:user) { User.create(role: :accountant) }
+      it "cannot update transaction" do
+        get :index, params: { id: user.id }
+        expect(response.body).to include("Can update transaction? false")
+      end
+    end
   end
 
   describe "GET /index_no_current_user" do

--- a/spec/test_app/app/controllers/users_controller.rb
+++ b/spec/test_app/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def index
-    @current_user = User.create
+    @current_user = params[:id] ? User.find(params[:id]) : User.create
     render file: Rails.root.join("app/views/users/index")
   end
 


### PR DESCRIPTION
The `current_user` wasn't passed correctly in this case, we also missed to test it. This PR addressed the issue.