### PR TITLE
Fix empty role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,3 +106,6 @@
 
 == Version 6.0.0
 1. Bug fix for `can?` and `cant?` when passing 2 arguments.
+
+== Version 6.0.1
+1. Bug fix for judgement issue when the user's role is an empty array

--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@ Bali is a to-the-point authorization library for Rails. Bali is short for Bulwar
 
 Why I created Bali?
 
-- I want to segment access rules per roles
+- Defining authorization rules are complicated, I want to make it natural and so much simper like Ruby
+- I want to easily segment authorization rules per roles
 - I don't want to marry rules with controllers' actions
-- I want an intuitive DSL that makes defining things fast
+- I want an intuitive DSL
 - I want to print those rules if I want, to see who can do what
 - On top of that, it integrates well with Rails (also, RSpec)
+
+Internally, Bali is quite complicated, but externally, Bali should be very easy and intuitive to use.
 
 ## Supported versions
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,28 @@ transactions = rule_scope(Transaction.all)
 
 It is important to note that a `scope` block must not be defined within a `role` block.
 
+## Usage outside of Rails
+
+This authorization library might be used outside of Rails, such as with Grape or Sinatra projects. However, although it should work as expected, such integration is not natively supported by Bali itself. Hence, additional works for such integration is needed.
+
+If ActiveRecord is not used, we need to add the following code into a user class.
+
+```ruby
+class User
+  extend Bali::Statics::Record
+  extract_roles_from :roles
+end
+```
+
+On the controller, we should add these helper modules:
+
+```ruby
+include Bali::Statics::ScopeRuler
+include Bali::Statics::Authorizer
+```
+
+Doing so allow us to use the `can?` and other functions on the controller. Bali should also be able to deduce the user's roles properly.
+
 ## Printing defined roles
 
 ```ruby

--- a/lib/bali/rails/action_controller.rb
+++ b/lib/bali/rails/action_controller.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
-require 'active_support/lazy_load_hooks'
+begin
+  require 'active_support/lazy_load_hooks'
 
-ActiveSupport.on_load :action_controller do
-  require "bali"
-  ::ActionController::Base.send :include, Bali::Statics::Authorizer
-  ::ActionController::Base.send :include, Bali::Statics::ScopeRuler
+  ActiveSupport.on_load :action_controller do
+    require "bali"
+    ::ActionController::Base.send :include, Bali::Statics::Authorizer
+    ::ActionController::Base.send :include, Bali::Statics::ScopeRuler
 
-  if defined? ::ActionController::API
-    ::ActionController::API.send :include, Bali::Statics::Authorizer
-    ::ActionController::API.send :include, Bali::Statics::ScopeRuler
+    if defined? ::ActionController::API
+      ::ActionController::API.send :include, Bali::Statics::Authorizer
+      ::ActionController::API.send :include, Bali::Statics::ScopeRuler
+    end
   end
+rescue LoadError
 end

--- a/lib/bali/rails/action_view.rb
+++ b/lib/bali/rails/action_view.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
-require 'active_support/lazy_load_hooks'
+begin
+  require 'active_support/lazy_load_hooks'
 
-ActiveSupport.on_load :action_view do
-  require "bali"
-  ::ActionView::Base.send :include, Bali::Statics::Authorizer
-  ::ActionView::Base.send :include, Bali::Statics::ScopeRuler
+  ActiveSupport.on_load :action_view do
+    require "bali"
+    ::ActionView::Base.send :include, Bali::Statics::Authorizer
+    ::ActionView::Base.send :include, Bali::Statics::ScopeRuler
+  end
+rescue LoadError
 end

--- a/lib/bali/rails/active_record.rb
+++ b/lib/bali/rails/active_record.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
-require 'active_support/lazy_load_hooks'
+begin
+  require 'active_support/lazy_load_hooks'
 
-ActiveSupport.on_load :active_record do
-  require "bali"
-  ::ActiveRecord::Base.send :extend, Bali::Statics::Record
+  ActiveSupport.on_load :active_record do
+    require "bali"
+    ::ActiveRecord::Base.send :extend, Bali::Statics::Record
+  end
+rescue LoadError
 end

--- a/lib/bali/rails/active_record.rb
+++ b/lib/bali/rails/active_record.rb
@@ -4,5 +4,5 @@ require 'active_support/lazy_load_hooks'
 
 ActiveSupport.on_load :active_record do
   require "bali"
-  ::ActiveRecord::Base.send :extend, Bali::Statics::ActiveRecord
+  ::ActiveRecord::Base.send :extend, Bali::Statics::Record
 end

--- a/lib/bali/role.rb
+++ b/lib/bali/role.rb
@@ -23,7 +23,7 @@ class Bali::Role
   def self.formalize(object)
     case object
     when *IDENTIFIER_CLASSES then [object]
-    when Array then object
+    when Array then (object.count == 0 ? nil : object)
     else formalize(extract_roles_from_object(object))
     end
   end

--- a/lib/bali/statics/active_record.rb
+++ b/lib/bali/statics/active_record.rb
@@ -1,13 +1,2 @@
-module Bali::Statics::ActiveRecord
-  def self.extended(cls)
-    cls.class_eval do
-      class << self
-        attr_accessor :role_field_for_authorization
-      end
-
-      def self.extract_roles_from method_name
-        @role_field_for_authorization = method_name
-      end
-    end
-  end
-end
+# This class is deprecated. Please use Bali::Statics::Record instead of this.
+Bali::Statics::ActiveRecord = Bali::Statics::Record

--- a/lib/bali/statics/record.rb
+++ b/lib/bali/statics/record.rb
@@ -1,0 +1,13 @@
+module Bali::Statics::Record
+  def self.extended(cls)
+    cls.class_eval do
+      class << self
+        attr_accessor :role_field_for_authorization
+      end
+
+      def self.extract_roles_from method_name
+        @role_field_for_authorization = method_name
+      end
+    end
+  end
+end

--- a/lib/bali/version.rb
+++ b/lib/bali/version.rb
@@ -1,3 +1,3 @@
 module Bali
-  VERSION = "6.0.0"
+  VERSION = "6.0.1"
 end

--- a/spec/statics/record_spec.rb
+++ b/spec/statics/record_spec.rb
@@ -1,9 +1,9 @@
-describe Bali::Statics::ActiveRecord do
+describe Bali::Statics::Record do
   describe ".role_field_for_authorization" do
     describe "each models" do
       it "has their own role field" do
         class MockRecordBase
-          extend Bali::Statics::ActiveRecord
+          extend Bali::Statics::Record
         end
 
         record_class_1 = Class.new(MockRecordBase) do
@@ -19,5 +19,9 @@ describe Bali::Statics::ActiveRecord do
         expect(MockRecordBase.role_field_for_authorization).to be_blank
       end
     end
+  end
+
+  it "is aliased as Bali::Statics::ActiveRecord" do
+    expect(Bali::Statics::ActiveRecord).to eq described_class
   end
 end

--- a/spec/transaction_rules_spec.rb
+++ b/spec/transaction_rules_spec.rb
@@ -26,6 +26,15 @@ describe "TransactionRules" do
     it "returns the judgement correctly for a class" do
       expect(TransactionRules.can?(:update, transaction)).to be_truthy
     end
+
+    context "when the role is an empty array" do
+      let(:role) { [] }
+
+      it "returns the judgement correctly for an object" do
+        expect(user.role).to eq []
+        expect(TransactionRules.can?(user, :update, transaction)).to be_truthy
+      end
+    end
   end
 
   describe ".cant?" do


### PR DESCRIPTION
Fix a bug when the role is an empty array:

```ruby
u = User.new
u.roles = []
```

The following will fail:

```ruby
can? user, :update, transaction
```

Assuming the following transaction rules

```ruby
class TransactionRules < Bali::Rules
  can :update, :unsettle
end
```

That is because, the `roles` of the `user` is empty, so there's no role to iterate for. In this case, internally, the `roles` should be treated the same as `nil`.  